### PR TITLE
feat: add assistant.sh launch script and shell alias setup

### DIFF
--- a/assistant.sh
+++ b/assistant.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Load .env
+if [[ -f .env ]]; then
+  set -a; source .env; set +a
+fi
+
+MODEL="${CLAUDE_MODEL:-claude-sonnet-4-6}"
+PROMPT="${*:-/loop 5m /heartbeat}"
+
+# shellcheck disable=SC2086
+exec claude \
+  --permission-mode="${CLAUDE_PERMISSION_MODE:-default}" \
+  --model="$MODEL" \
+  --name="${ASSISTANT_NAME:-kvido}" \
+  ${CLAUDE_ADDITIONAL_OPTIONS:-} \
+  "$PROMPT"

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -78,6 +78,22 @@ memory/
 
 If the project does not have a `CLAUDE.md`, copy `CLAUDE.md.template` from the plugin as a starting point.
 
+### f) Shell alias
+
+Offer the user a shell alias for quick launching:
+
+1. Derive alias name from `memory/persona.md` assistant name (lowercase, strip diacritics via `iconv -f utf-8 -t ascii//TRANSLIT`). Fallback: `kvido`.
+2. Ask: "Do you want to create a shell alias `<name>` for quick launching?"
+3. If yes:
+   - Detect shell rc file: if `$SHELL` contains `zsh` → `~/.zshrc`, else `~/.bashrc`
+   - Resolve plugin path: the `assistant.sh` script is located in the plugin root (parent of this `commands/` directory). Use the absolute path.
+   - Append to rc file (only if alias not already present):
+     ```bash
+     alias <name>='<absolute_path_to_plugin>/assistant.sh'
+     ```
+   - Inform user: "Alias created. Run `source ~/.zshrc` (or `~/.bashrc`) or restart your shell to activate it."
+4. If no: skip silently.
+
 
 ## Step 2: Structure Bootstrap
 


### PR DESCRIPTION
## Summary

- Add `assistant.sh` — a bash launch script that starts Claude Code with sensible defaults (sonnet model, default permission mode, `/loop 5m /heartbeat`), fully configurable via env vars
- Extend `/setup` with step 1f offering to create a shell alias for quick launching from anywhere

## Test plan

- [ ] Verify `assistant.sh` is executable and launches Claude Code correctly
- [ ] Run `/setup` and confirm alias creation is offered after step 1e
- [ ] Confirm alias works after sourcing shell rc file

🤖 Generated with [Claude Code](https://claude.com/claude-code)