### PR TITLE
refactor: migrate launcher to official Claude Code env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ After setup, use the shell alias (offered during `/setup`) or:
 ./assistant.sh /morning           # morning briefing
 ```
 
-Environment variables for `assistant.sh`:
+Kvido-specific environment variables (set in `.env` or shell):
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `CLAUDE_MODEL` | `claude-sonnet-4-6` | Model to use |
-| `CLAUDE_PERMISSION_MODE` | `default` | Permission mode (`default`, `acceptEdits`, etc.) |
-| `ASSISTANT_NAME` | `kvido` | Session name |
-| `CLAUDE_ADDITIONAL_OPTIONS` | | Extra CLI flags |
+| `KVIDO_NAME` | `kvido` | Session name (`--name`) |
+| `KVIDO_PERMISSION_MODE` | `default` | Permission mode (`--permission-mode`) |
+| `KVIDO_EXTRA_ARGS` | | Extra CLI flags |
+
+All official `ANTHROPIC_*` and `CLAUDE_CODE_*` env vars (model, effort, API key, proxy, ...) work automatically — just set them in `.env` or your environment. See [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables).
 
 ## Daily Usage
 

--- a/plugins/kvido/kvido
+++ b/plugins/kvido/kvido
@@ -73,20 +73,25 @@ case "${1:-}" in
     exec bash "$TARGET" "$@"
     ;;
   *)
-    # Claude launcher — replaces assistant.sh
+    # Claude launcher — official env vars (ANTHROPIC_*, CLAUDE_CODE_*) are
+    # read automatically by Claude Code. Only KVIDO_* vars map to CLI flags
+    # that have no env var equivalent.
     if [[ -f .env ]]; then
       set -a; source .env; set +a
     fi
 
-    MODEL="${CLAUDE_MODEL:-claude-sonnet-4-6}"
     PROMPT="${*:-/loop 5m /heartbeat}"
 
-    # shellcheck disable=SC2086
-    exec claude \
-      --permission-mode="${CLAUDE_PERMISSION_MODE:-default}" \
-      --model="$MODEL" \
-      --name="${ASSISTANT_NAME:-kvido}" \
-      ${CLAUDE_ADDITIONAL_OPTIONS:-} \
-      "$PROMPT"
+    ARGS=(
+      --name "${KVIDO_NAME:-kvido}"
+      --permission-mode "${KVIDO_PERMISSION_MODE:-default}"
+    )
+
+    if [[ -n "${KVIDO_EXTRA_ARGS:-}" ]]; then
+      # shellcheck disable=SC2086
+      ARGS+=($KVIDO_EXTRA_ARGS)
+    fi
+
+    exec claude "${ARGS[@]}" "$PROMPT"
     ;;
 esac


### PR DESCRIPTION
## Summary

- Replace custom env vars (`CLAUDE_MODEL`, `CLAUDE_PERMISSION_MODE`, `ASSISTANT_NAME`, `CLAUDE_ADDITIONAL_OPTIONS`) with `KVIDO_*` prefix for launcher-specific vars
- Official `ANTHROPIC_*` and `CLAUDE_CODE_*` env vars (model, effort, API key, proxy, Bedrock/Vertex, ...) now work automatically via passthrough — no need to map them in the launcher
- Updated README env vars table and added reference to Claude Code docs

## Test plan

- [ ] Verify `kvido --root` still works
- [ ] Verify `kvido /morning` launches Claude with correct flags
- [ ] Verify `ANTHROPIC_MODEL=claude-opus-4-6 kvido` picks up the model automatically
- [ ] Verify `KVIDO_NAME=test kvido` sets session name

🤖 Generated with [Claude Code](https://claude.com/claude-code)