### PR TITLE
feat: kvido CLI shortcut commands

### DIFF
--- a/plugins/kvido/CLAUDE.md
+++ b/plugins/kvido/CLAUDE.md
@@ -34,30 +34,30 @@ This repo is a Claude Code plugin marketplace. Each plugin is in `plugins/<name>
 
 ### kvido CLI
 
-The `kvido` dispatcher script (`plugins/kvido/kvido`) resolves the plugin install path from the Claude Code registry (`~/.claude/plugins/installed_plugins.json`) and dispatches to target scripts. All SKILL.md instructions use `kvido skills/...` commands.
+The `kvido` dispatcher script (`plugins/kvido/kvido`) resolves the plugin install path from the Claude Code registry (`~/.claude/plugins/installed_plugins.json`) and dispatches to target scripts. Commands use short names (e.g. `kvido task`, `kvido slack`) — auto-resolved from `skills/`.
 
 Installation: `kvido --install` (symlinks to `~/.local/bin/kvido`). Done automatically by `/kvido:setup`.
 
 Usage:
 ```bash
-kvido skills/heartbeat/heartbeat.sh          # run heartbeat data gather
-kvido skills/worker/task.sh list todo        # list worker queue
-kvido skills/slack/slack.sh send chat ...    # send Slack message
-kvido skills/config.sh 'sources.gitlab.repos' # read config
+kvido heartbeat          # run heartbeat data gather
+kvido task list todo        # list worker queue
+kvido slack send chat ...    # send Slack message
+kvido config 'sources.gitlab.repos' # read config
 kvido --root                                 # print plugin install path
 ```
 
 ### Core loop
 
-1. **Heartbeat** (`skills/heartbeat/`) — cron-based orchestrator (default 10min). Manages chat, worker, planner dispatch via TodoWrite/TodoRead. Owns all Slack delivery through `kvido skills/slack/slack.sh`.
+1. **Heartbeat** (`skills/heartbeat/`) — cron-based orchestrator (default 10min). Manages chat, worker, planner dispatch via TodoWrite/TodoRead. Owns all Slack delivery through `kvido slack`.
 2. **Planner** (`agents/planner.md` + `skills/planner/`) — runs every Nth heartbeat. Fetches data from sources, detects changes, generates notifications/triage items, dispatches agents (morning/eod).
-3. **Worker** (`agents/worker.md` + `skills/worker/`) — async task queue backed by local markdown files in `state/tasks/`. Max 1 concurrent. Model selected by task size (s/m → sonnet, l/xl → opus). All task operations via `kvido skills/worker/task.sh`.
+3. **Worker** (`agents/worker.md` + `skills/worker/`) — async task queue backed by local markdown files in `state/tasks/`. Max 1 concurrent. Model selected by task size (s/m → sonnet, l/xl → opus). All task operations via `kvido task`.
 4. **Chat-agent** (`agents/chat-agent.md`) — dispatched by heartbeat for non-trivial Slack DM messages (lookups, task creation, pipeline responses). Trivial messages (greetings, sleep, turbo, cancel) heartbeat handles inline.
 
 ### Data flow
 
-- **Sources** — separate plugins (`kvido-gitlab`, `kvido-jira`, etc.). Discovered at runtime via `kvido skills/discover-sources.sh` which reads `~/.claude/plugins/installed_plugins.json`.
-- **Config** — `kvido skills/config.sh 'flat.key'` reads flat dot-notation YAML frontmatter from `.claude/kvido.local.md`
+- **Sources** — separate plugins (`kvido-gitlab`, `kvido-jira`, etc.). Discovered at runtime via `kvido discover-sources` which reads `~/.claude/plugins/installed_plugins.json`.
+- **Config** — `kvido config 'flat.key'` reads flat dot-notation YAML frontmatter from `.claude/kvido.local.md`
 - **State** (`state/`) — ephemeral runtime: `current.md`, `today.md`, `heartbeat-state.json`, `tasks/{triage,todo,in-progress,done,failed,cancelled}/`
 - **Memory** (`memory/`) — persistent: `memory.md`, journals, projects, people, decisions, learnings
 - **Librarian** (`agents/librarian.md`) — memory consolidation, extraction from journals, cleanup, auto-memory sync
@@ -74,7 +74,7 @@ kvido --root                                 # print plugin install path
 
 ### Agents
 
-All agents are dispatched by heartbeat with `run_in_background: true`. They return NL output — **never send Slack messages directly**. Heartbeat parses output and delivers via `kvido skills/slack/slack.sh`. Trivial chat messages (greetings, sleep, turbo, cancel) are handled by heartbeat inline without dispatching an agent.
+All agents are dispatched by heartbeat with `run_in_background: true`. They return NL output — **never send Slack messages directly**. Heartbeat parses output and delivers via `kvido slack`. Trivial chat messages (greetings, sleep, turbo, cancel) are handled by heartbeat inline without dispatching an agent.
 
 | Agent | Trigger | Purpose |
 |-------|---------|---------|
@@ -90,8 +90,8 @@ All agents are dispatched by heartbeat with `run_in_background: true`. They retu
 ### Key conventions
 
 - All bash scripts use `set -euo pipefail`
-- Config access: `kvido skills/config.sh '.path.to.key'` (never parse kvido.local.md directly)
-- Worker queue: local markdown files in `state/tasks/` organized by status folders (triage, todo, in-progress, done, failed, cancelled). All operations via `kvido skills/worker/task.sh`
+- Config access: `kvido config '.path.to.key'` (never parse kvido.local.md directly)
+- Worker queue: local markdown files in `state/tasks/` organized by status folders (triage, todo, in-progress, done, failed, cancelled). All operations via `kvido task`
 - Dispatch tracking: TodoWrite/TodoRead (not file-based locks)
 - Language: All prompts default to English. Runtime language is configured in the user's `memory/persona.md`.
 - Hook: `hooks/pre-compact.sh` injects state summary before context compaction
@@ -102,5 +102,5 @@ All agents are dispatched by heartbeat with `run_in_background: true`. They retu
 - Agents are markdown templates in `agents/` with YAML frontmatter (name, description, tools, model)
 - Commands in `commands/` are thin wrappers that delegate to SKILL.md files
 - Templates for Slack messages are JSON files in `skills/slack/templates/`
-- All bash script invocations use `kvido skills/...` (the `kvido` CLI resolves the plugin install path)
+- All bash script invocations use `kvido <name>` short commands (e.g. `kvido task`, `kvido slack`)
 - No build step, no tests — validate by reading the plugin conventions and running `/kvido:setup` health check

--- a/plugins/kvido/agents/chat-agent.md
+++ b/plugins/kvido/agents/chat-agent.md
@@ -40,7 +40,7 @@ If the message contains an action verb with scope > 1 lookup ("go through", "wri
 2. Estimate `priority`: "urgently"/"now"/"asap" → `urgent`, "today" → `high`, default → `medium`
 3. Call:
    ```bash
-   TASK_SLUG=$(skills/worker/task.sh create \
+   TASK_SLUG=$(kvido task create \
      --instruction "<instruction>" \
      --size <s|m|l|xl> \
      --priority <urgent|high|medium|low> \
@@ -60,7 +60,7 @@ If the message is a reply to a worker task thread or contains "pipeline"/"brains
    for f in state/tasks/todo/*.md state/tasks/in-progress/*.md; do
      [[ -f "$f" ]] || continue
      SLUG=$(basename "$f" .md)
-     TASK_DATA=$(skills/worker/task.sh read "$SLUG" 2>/dev/null) || continue
+     TASK_DATA=$(kvido task read "$SLUG" 2>/dev/null) || continue
      PIPELINE=$(echo "$TASK_DATA" | grep '^PIPELINE=' | cut -d= -f2-)
      if [[ "$PIPELINE" == "true" ]]; then
        PHASE=$(echo "$TASK_DATA" | grep '^PHASE=' | cut -d= -f2-)
@@ -78,8 +78,8 @@ If the message is a reply to a worker task thread or contains "pipeline"/"brains
 If the message contains ✅/❌/👍/👎 or "approved"/"rejected" and `state/planner-state.md` section `## Triage Pending` exists:
 
 1. Parse the reply — assign to items by order
-2. Approve: `skills/worker/task.sh move <slug> todo`
-3. Reject: `skills/worker/task.sh note <slug> "Rejected via chat" && skills/worker/task.sh move <slug> cancelled`
+2. Approve: `kvido task move <slug> todo`
+3. Reject: `kvido task note <slug> "Rejected via chat" && kvido task move <slug> cancelled`
 4. Modify: add feedback as comment
 5. Delete processed items from `## Triage Pending`
 

--- a/plugins/kvido/agents/self-improver.md
+++ b/plugins/kvido/agents/self-improver.md
@@ -26,7 +26,7 @@ Before generating new proposals, evaluate the results of previous ones.
    for f in state/tasks/done/*.md state/tasks/cancelled/*.md; do
      [[ -f "$f" ]] || continue
      SLUG=$(basename "$f" .md)
-     TASK_DATA=$(skills/worker/task.sh read "$SLUG" 2>/dev/null) || continue
+     TASK_DATA=$(kvido task read "$SLUG" 2>/dev/null) || continue
      src=$(echo "$TASK_DATA" | grep '^SOURCE=' | cut -d= -f2-)
      [[ "$src" == "self-improver" ]] || continue
      updated=$(echo "$TASK_DATA" | grep '^UPDATED_AT=' | cut -d= -f2-)
@@ -71,7 +71,7 @@ Use this limit instead of the fixed "max 5" in subsequent steps.
     for f in "$d"*.md; do
       [[ -f "$f" ]] || continue
       SLUG=$(basename "$f" .md)
-      TASK_DATA=$(skills/worker/task.sh read "$SLUG" 2>/dev/null) || continue
+      TASK_DATA=$(kvido task read "$SLUG" 2>/dev/null) || continue
       src=$(echo "$TASK_DATA" | grep '^SOURCE=' | cut -d= -f2-)
       [[ "$src" == "self-improver" ]] || continue
       title=$(echo "$TASK_DATA" | grep '^TITLE=' | cut -d= -f2-)
@@ -110,7 +110,7 @@ Analyze repeated task patterns to identify automatable patterns.
    for f in state/tasks/done/*.md; do
      [[ -f "$f" ]] || continue
      SLUG=$(basename "$f" .md)
-     TASK_DATA=$(skills/worker/task.sh read "$SLUG" 2>/dev/null) || continue
+     TASK_DATA=$(kvido task read "$SLUG" 2>/dev/null) || continue
      title=$(echo "$TASK_DATA" | grep '^TITLE=' | cut -d= -f2-)
      echo "$SLUG | $title"
    done
@@ -147,7 +147,7 @@ For patterns identified in Step 2b with 3+ repetitions generate skill drafts.
 
 1. For a qualifying pattern create a task of type `[SELF-IMPROVE/SKILL]`:
    ```bash
-   skills/worker/task.sh create \
+   kvido task create \
      --title "[SELF-IMPROVE/SKILL] <skill name or modification>" \
      --instruction "<see format below>" \
      --source self-improver \
@@ -194,7 +194,7 @@ IF proposal targets plugin code (shipped skill/agent/command from plugin cache):
 #### Local proposals (workspace changes)
 
 ```bash
-skills/worker/task.sh create \
+kvido task create \
   --title "[SELF-IMPROVE/<TYPE>] description" \
   --instruction "<description of problem and proposed solution>" \
   --source self-improver \

--- a/plugins/kvido/agents/worker.md
+++ b/plugins/kvido/agents/worker.md
@@ -26,7 +26,7 @@ PHASE: {{PHASE}}
 
 2. Verify the task has not been cancelled/completed:
    ```bash
-   STATUS=$(skills/worker/task.sh find {{TASK_SLUG}})
+   STATUS=$(kvido task find {{TASK_SLUG}})
    [[ "$STATUS" =~ ^(done|failed|cancelled)$ ]] && exit 0
    ```
 
@@ -46,17 +46,17 @@ PHASE: {{PHASE}}
 7. `state/today.md` log: `- **HH:MM** [worker] {{TASK_SLUG}}: <summary>`
 
 8. If worktree:
-     `skills/worker/task.sh note {{TASK_SLUG}} "## Result\nBranch: <branch>, pushed. <description>"`
-     `skills/worker/task.sh move {{TASK_SLUG}} done`
+     `kvido task note {{TASK_SLUG}} "## Result\nBranch: <branch>, pushed. <description>"`
+     `kvido task move {{TASK_SLUG}} done`
    If pipeline phase transition:
-     `skills/worker/task.sh update {{TASK_SLUG}} phase review`
-     `skills/worker/task.sh move {{TASK_SLUG}} todo`
+     `kvido task update {{TASK_SLUG}} phase review`
+     `kvido task move {{TASK_SLUG}} todo`
    If standard completion:
-     `skills/worker/task.sh note {{TASK_SLUG}} "## Result\n<summary>"`
-     `skills/worker/task.sh move {{TASK_SLUG}} done`
+     `kvido task note {{TASK_SLUG}} "## Result\n<summary>"`
+     `kvido task move {{TASK_SLUG}} done`
    On error:
-     `skills/worker/task.sh note {{TASK_SLUG}} "## Failed\n<reason>"`
-     `skills/worker/task.sh move {{TASK_SLUG}} failed`
+     `kvido task note {{TASK_SLUG}} "## Failed\n<reason>"`
+     `kvido task move {{TASK_SLUG}} failed`
 
 ## Output format
 
@@ -85,7 +85,7 @@ Type: worker-error
 ```
 
 ## Error handling
-1. `skills/worker/task.sh note {{TASK_SLUG}} "## Failed\n<reason>"`
-2. `skills/worker/task.sh move {{TASK_SLUG}} failed`
+1. `kvido task note {{TASK_SLUG}} "## Failed\n<reason>"`
+2. `kvido task move {{TASK_SLUG}} failed`
 3. Include error in NL output: `Error: Worker failed {{TASK_SLUG}} — <reason>`
 4. Write to `memory/errors.md`

--- a/plugins/kvido/commands/heartbeat.md
+++ b/plugins/kvido/commands/heartbeat.md
@@ -18,7 +18,7 @@ Call `CronList`. If no job contains the word `heartbeat`, call `CronCreate`:
 - `recurring`: `true`
 - `prompt`: `/kvido:heartbeat`
 
-After creating the cron, save the job ID to `state/heartbeat-state.json` via `kvido skills/heartbeat/heartbeat-state.sh set cron_job_id "<job_id>"` and `kvido skills/heartbeat/heartbeat-state.sh set active_preset "10m"`.
+After creating the cron, save the job ID to `state/heartbeat-state.json` via `kvido heartbeat-state set cron_job_id "<job_id>"` and `kvido heartbeat-state set active_preset "10m"`.
 
 Create the cron silently — print nothing unless an error occurs.
 

--- a/plugins/kvido/commands/setup.md
+++ b/plugins/kvido/commands/setup.md
@@ -41,7 +41,7 @@ If a required tool is missing, inform the user and offer installation. Do not pr
 
 ### Source plugins
 
-Run `kvido skills/discover-sources.sh` to list installed source plugins. Show the user what is installed and what is available:
+Run `kvido discover-sources` to list installed source plugins. Show the user what is installed and what is available:
 
 | Source plugin | Prerequisite | Status |
 |---------------|-------------|--------|
@@ -126,15 +126,15 @@ Offer the user a shell alias for quick launching:
 
 ### g) Source plugin config validation
 
-For each installed source plugin (via `kvido skills/discover-sources.sh`), verify that `.claude/kvido.local.md` contains the required config keys. Use `kvido skills/config.sh` to check.
+For each installed source plugin (via `kvido discover-sources`), verify that `.claude/kvido.local.md` contains the required config keys. Use `kvido config` to check.
 
 | Plugin | Required keys | Check |
 |--------|--------------|-------|
-| kvido-gitlab | At least one repo: `sources.gitlab.repos` must have children | `kvido skills/config.sh --keys 'sources.gitlab.repos'` returns non-empty |
-| kvido-jira | At least one project: `sources.jira.projects` must have children with `filter` | `kvido skills/config.sh --keys 'sources.jira.projects'` returns non-empty |
-| kvido-slack | At least one channel or DM config | `kvido skills/config.sh --keys 'sources.slack.channels'` or `kvido skills/config.sh --keys 'sources.slack.dm_channels'` returns non-empty |
+| kvido-gitlab | At least one repo: `sources.gitlab.repos` must have children | `kvido config --keys 'sources.gitlab.repos'` returns non-empty |
+| kvido-jira | At least one project: `sources.jira.projects` must have children with `filter` | `kvido config --keys 'sources.jira.projects'` returns non-empty |
+| kvido-slack | At least one channel or DM config | `kvido config --keys 'sources.slack.channels'` or `kvido config --keys 'sources.slack.dm_channels'` returns non-empty |
 | kvido-calendar | Categories (optional, works without) | No required keys — skip |
-| kvido-gmail | Watch query | `kvido skills/config.sh 'sources.gmail.watch_query'` exists |
+| kvido-gmail | Watch query | `kvido config 'sources.gmail.watch_query'` exists |
 | kvido-sessions | Idle threshold (optional, has default) | No required keys — skip |
 
 For each missing config:
@@ -209,10 +209,10 @@ command -v jq &>/dev/null || echo "WARNING: jq not found"
 ```
 
 ### Config validation
-Run `kvido skills/config.sh --validate` to check config format. For each installed source plugin, verify required keys exist (same checks as Step 1g). Log warnings for missing keys.
+Run `kvido config --validate` to check config format. For each installed source plugin, verify required keys exist (same checks as Step 1g). Log warnings for missing keys.
 
 ### Source health
-Run `kvido skills/discover-sources.sh` to get installed source plugins. For each installed source, read its SKILL.md. If the SKILL.md defines a `health` capability, run it and write results to `state/source-health.json`.
+Run `kvido discover-sources` to get installed source plugins. For each installed source, read its SKILL.md. If the SKILL.md defines a `health` capability, run it and write results to `state/source-health.json`.
 
 Skip sources that are not installed or do not define a health capability.
 

--- a/plugins/kvido/kvido
+++ b/plugins/kvido/kvido
@@ -8,14 +8,16 @@
 # Usage:
 #   kvido                                     # launch Claude with heartbeat loop
 #   kvido /kvido:morning                      # launch Claude with custom prompt
-#   kvido skills/heartbeat/heartbeat.sh       # dispatch to plugin script
-#   kvido skills/worker/task.sh list todo     # dispatch with args
+#   kvido task list todo                      # shortcut for skills/worker/task.sh
+#   kvido heartbeat-state set key value       # shortcut for skills/heartbeat/heartbeat-state.sh
+#   kvido config 'sources.gitlab.repos'       # shortcut for skills/config.sh
 #   kvido --root                              # print plugin root path
 #   kvido --install                           # symlink to ~/.local/bin/kvido
 #
 # Routing:
 #   --root / --install    → built-in commands
-#   skills/* / agents/*   → script dispatch (resolved to plugin install path)
+#   skills/* / agents/*   → direct dispatch (backward compat)
+#   <name> [args]         → auto-resolve script by name from skills/
 #   everything else       → Claude launcher
 # =============================================================================
 
@@ -73,6 +75,25 @@ case "${1:-}" in
     exec bash "$TARGET" "$@"
     ;;
   *)
+    # Try auto-resolve as short command name → skills/*.sh
+    _RESOLVED=""
+    if [[ -n "${1:-}" ]]; then
+      _NAME="${1%.sh}"
+      if [[ -f "$KVIDO_ROOT/skills/$_NAME.sh" ]]; then
+        _RESOLVED="$KVIDO_ROOT/skills/$_NAME.sh"
+      elif [[ -f "$KVIDO_ROOT/skills/$_NAME/$_NAME.sh" ]]; then
+        _RESOLVED="$KVIDO_ROOT/skills/$_NAME/$_NAME.sh"
+      else
+        _MATCH=$(find "$KVIDO_ROOT/skills" -name "$_NAME.sh" -type f 2>/dev/null | head -1)
+        [[ -n "$_MATCH" ]] && _RESOLVED="$_MATCH"
+      fi
+    fi
+
+    if [[ -n "$_RESOLVED" ]]; then
+      shift
+      exec bash "$_RESOLVED" "$@"
+    fi
+
     # Claude launcher — official env vars (ANTHROPIC_*, CLAUDE_CODE_*) are
     # read automatically by Claude Code. Only KVIDO_* vars map to CLI flags
     # that have no env var equivalent.

--- a/plugins/kvido/skills/eod/SKILL.md
+++ b/plugins/kvido/skills/eod/SKILL.md
@@ -38,7 +38,7 @@ From the filtered records extract:
 
 Include summary in the journal entry (Step 2) as section `## Token Usage`.
 
-Run `kvido skills/discover-sources.sh` to find installed source plugins. For each discovered source relevant to EOD (sessions, gitlab), read its `skills/source-*/SKILL.md` from the install path and call the EOD fetch command.
+Run `kvido discover-sources` to find installed source plugins. For each discovered source relevant to EOD (sessions, gitlab), read its `skills/source-*/SKILL.md` from the install path and call the EOD fetch command.
 
 **Uncommitted work detection** — read `.claude/kvido.local.md`, for each repo:
 
@@ -73,7 +73,7 @@ Format:
 
 ## Goals Progress
 <!-- Completed tasks today: check state/tasks/done/*.md, filter by updated_at today -->
-<!-- skills/worker/task.sh list done → for each task.sh read <slug> → filter updated_at == today -->
+<!-- kvido task list done → for each task.sh read <slug> → filter updated_at == today -->
 <!-- Group by goal field in frontmatter. Tasks without goal shown under "Other". -->
 <!-- Format: ### Goal Name\n- <slug>: title -->
 

--- a/plugins/kvido/skills/heartbeat/SKILL.md
+++ b/plugins/kvido/skills/heartbeat/SKILL.md
@@ -21,7 +21,7 @@ Tone and style per `memory/persona.md` (section Heartbeat). If persona missing, 
 Run:
 
 ```bash
-kvido skills/heartbeat/heartbeat.sh
+kvido heartbeat
 ```
 
 Output: `TIMESTAMP`, `ITERATION`, `NIGHT`, `ZONE`, `TARGET_PRESET`, `ACTIVE_PRESET`, `CRON_JOB_ID`, `INTERACTION_AGO_MIN`, `PLANNER_DUE`, `NEXT_TASK`, `SLEEP_ACTIVE`, `SLEEP_UNTIL`, `CHAT_MESSAGES_START...CHAT_MESSAGES_END`.
@@ -36,7 +36,7 @@ Read `state/today.md` and `state/current.md` for context.
 
 `CRON_JOB_ID` from heartbeat-state.json may be stale (from a previous session — cron jobs are session-only). Call `CronList` and compare:
 - If `CRON_JOB_ID` is not in the current cron list, find the actual heartbeat cron job (prompt contains "heartbeat")
-- If found: update state with the actual job ID via `kvido skills/heartbeat/heartbeat-state.sh set cron_job_id "<actual_id>"`
+- If found: update state with the actual job ID via `kvido heartbeat-state set cron_job_id "<actual_id>"`
 - If no heartbeat cron exists: this is an orphaned run — log and skip adaptive interval logic
 
 ### Recovery check
@@ -68,21 +68,21 @@ Use `TodoRead` to list all existing tasks. If any `in_progress` tasks exist from
    - Sleep mode ("going to sleep", "good night", "pause", "sleep"):
      ```bash
      SLEEP_UNTIL=$(date -d "tomorrow 06:00" -Iseconds)  # or parsed time
-     kvido skills/heartbeat/heartbeat-state.sh set sleep_until "$SLEEP_UNTIL"
+     kvido heartbeat-state set sleep_until "$SLEEP_UNTIL"
      ```
    - Turbo mode ("turbo"):
      ```bash
      TURBO_UNTIL=$(date -d "+30 min" -Iseconds)  # or parsed duration
-     kvido skills/heartbeat/heartbeat-state.sh set turbo_until "$TURBO_UNTIL"
+     kvido heartbeat-state set turbo_until "$TURBO_UNTIL"
      ```
    - Cancel ("cancel <slug>"):
      ```bash
-     kvido skills/worker/task.sh note <slug> "Cancelled via chat"
-     kvido skills/worker/task.sh move <slug> cancelled
+     kvido task note <slug> "Cancelled via chat"
+     kvido task move <slug> cancelled
      ```
    - Simple status questions answerable from loaded state/current.md and state/today.md
 
-   For trivial: compose response, create `notify:chat:<ts>` TODO (in_progress), deliver via `kvido skills/slack/slack.sh send|reply chat --var message="<response>"`, mark notify TODO completed. Log: `- **HH:MM** [chat] <summary>`
+   For trivial: compose response, create `notify:chat:<ts>` TODO (in_progress), deliver via `kvido slack send|reply chat --var message="<response>"`, mark notify TODO completed. Log: `- **HH:MM** [chat] <summary>`
 
    **Non-trivial** — requires MCP lookup, research, task creation, or pipeline response:
    - If no active `chat:*` task:
@@ -90,10 +90,10 @@ Use `TodoRead` to list all existing tasks. If any `in_progress` tasks exist from
      - Load last 10 messages; if thread reply, load whole thread
      - Dispatch `chat-agent` (`run_in_background: true`) with template vars: CHAT_HISTORY, NEW_MESSAGE, THREAD_TS, CURRENT_STATE, MEMORY
    - If active `chat:*` task exists:
-     - Send ack: `kvido skills/slack/slack.sh send chat --var message="One moment..."`
+     - Send ack: `kvido slack send chat --var message="One moment..."`
      - `TodoWrite` task `chat:<ts>` with status `pending`
 
-   Update: `kvido skills/heartbeat/heartbeat-state.sh set last_chat_ts "<ts>"` + `kvido skills/heartbeat/heartbeat-state.sh set last_interaction_ts "$(date -Iseconds)"`
+   Update: `kvido heartbeat-state set last_chat_ts "<ts>"` + `kvido heartbeat-state set last_interaction_ts "$(date -Iseconds)"`
 
 4. **Agent completion:** When a dispatched chat-agent completes (background task finishes), in the next heartbeat iteration:
    - `TodoRead` -- find `chat:*` tasks with status `in_progress`
@@ -107,7 +107,7 @@ Use `TodoRead` to list all existing tasks. If any `in_progress` tasks exist from
 
 ### Creating triage tasks
 
-Triage TODOs are created in Step 2c when heartbeat delivers a `triage-item` notification through `kvido skills/slack/slack.sh`. The returned `ts` is written into `triage:<issue_id>` TODO description. No CHAT_MESSAGES scanning needed for triage creation.
+Triage TODOs are created in Step 2c when heartbeat delivers a `triage-item` notification through `kvido slack`. The returned `ts` is written into `triage:<issue_id>` TODO description. No CHAT_MESSAGES scanning needed for triage creation.
 
 ### Polling reactions
 
@@ -115,7 +115,7 @@ Use `TodoRead` to find all `triage:*` tasks (not completed). Build JSON input an
 
 ```bash
 # Build input: [{"slug":"fix-auth-bug","ts":"1773..."},...]
-echo "$TRIAGE_JSON" | kvido skills/heartbeat/triage-poll.sh
+echo "$TRIAGE_JSON" | kvido triage-poll
 ```
 
 Output: `[{"slug":"fix-auth-bug","result":"approved|rejected|pending"},...]`
@@ -129,11 +129,11 @@ For each result:
 
 ## Step 2c: Agent Output Processing & Delivery
 
-When a background agent completes (detected via TodoRead — task status is `in_progress` but agent has returned result), process its output and deliver directly from heartbeat via `kvido skills/slack/slack.sh`.
+When a background agent completes (detected via TodoRead — task status is `in_progress` but agent has returned result), process its output and deliver directly from heartbeat via `kvido slack`.
 
 ### Delivery rules
 
-Heartbeat is responsible for parsing agent output into structured fields, deciding `immediate|batch|silent`, choosing template, and calling `kvido skills/slack/slack.sh`.
+Heartbeat is responsible for parsing agent output into structured fields, deciding `immediate|batch|silent`, choosing template, and calling `kvido slack`.
 
 Rules:
 - `chat-reply` is always `immediate`
@@ -149,9 +149,9 @@ Rules:
 ### Common pattern (all agent completions)
 
 1. Read agent's NL output (returned by Agent tool)
-2. Parse `total_tokens` + `duration_ms` from `<usage>` tag → `kvido skills/heartbeat/heartbeat-state.sh log-activity <type> execute --tokens ... --duration_ms ...`
+2. Parse `total_tokens` + `duration_ms` from `<usage>` tag → `kvido heartbeat-state log-activity <type> execute --tokens ... --duration_ms ...`
 3. Create `notify:<type>:<id>` TODO (in_progress)
-4. Apply delivery rules → deliver via `kvido skills/slack/slack.sh` → mark TODO completed
+4. Apply delivery rules → deliver via `kvido slack` → mark TODO completed
 5. Mark agent task as completed
 
 ### Per-agent specifics
@@ -165,7 +165,7 @@ Rules:
 
 ### Batch flush
 
-Flush `notify:*` TODOs with `pending` status when: planner/full iteration runs, or focus mode switches off. Re-deliver stored template+vars via `kvido skills/slack/slack.sh`. On failure, leave `pending` for next flush.
+Flush `notify:*` TODOs with `pending` status when: planner/full iteration runs, or focus mode switches off. Re-deliver stored template+vars via `kvido slack`. On failure, leave `pending` for next flush.
 
 ---
 
@@ -176,7 +176,7 @@ Flush `notify:*` TODOs with `pending` status when: planner/full iteration runs, 
    - `TodoWrite` task `planner` with status `in_progress` and description `"Planner dispatch at <timestamp>"`
    - Dispatch `planner` agent (`run_in_background: true`)
    - Pass context: `CURRENT_STATE` (state/current.md), `MEMORY` (memory/memory.md)
-   - Log activity: `kvido skills/heartbeat/heartbeat-state.sh log-activity planner dispatch --detail "iteration <N>"`
+   - Log activity: `kvido heartbeat-state log-activity planner dispatch --detail "iteration <N>"`
    - Log: `- **HH:MM** [planner] Dispatched`
 3. If planner agent completed since last check -- update `planner` task to `completed`.
 
@@ -185,14 +185,14 @@ Flush `notify:*` TODOs with `pending` status when: planner/full iteration runs, 
 ## Step 4: Worker Dispatch
 
 1. `TodoRead` — if any `worker:*` in_progress → skip (max 1 concurrent).
-2. `NEXT_TASK=$(kvido skills/worker/task.sh list todo --sort priority | head -1)` — empty → skip.
-3. `kvido skills/worker/task.sh move "$NEXT_TASK" in-progress` + `kvido skills/worker/task.sh read "$NEXT_TASK"` → get SIZE, PRIORITY, SOURCE_REF, INSTRUCTION, PHASE, WORKTREE.
-   - Pipeline task without phase → set default: `kvido skills/worker/task.sh update "$NEXT_TASK" phase brainstorm|implement`
+2. `NEXT_TASK=$(kvido task list todo --sort priority | head -1)` — empty → skip.
+3. `kvido task move "$NEXT_TASK" in-progress` + `kvido task read "$NEXT_TASK"` → get SIZE, PRIORITY, SOURCE_REF, INSTRUCTION, PHASE, WORKTREE.
+   - Pipeline task without phase → set default: `kvido task update "$NEXT_TASK" phase brainstorm|implement`
 4. `TodoWrite` task `worker:<NEXT_TASK>` (in_progress).
 5. Model from config: `models.<SIZE>` (or `urgent_model` if PRIORITY==urgent).
 6. Dispatch `worker` agent (`run_in_background: true`, model per size). If `WORKTREE=true` → add `isolation: "worktree"`.
-7. Log activity via `kvido skills/heartbeat/heartbeat-state.sh log-activity worker dispatch`.
-8. If SOURCE_REF not empty → send ack via `kvido skills/slack/slack.sh reply "<SOURCE_REF>" chat --var message="Task accepted..."`.
+7. Log activity via `kvido heartbeat-state log-activity worker dispatch`.
+8. If SOURCE_REF not empty → send ack via `kvido slack reply "<SOURCE_REF>" chat --var message="Task accepted..."`.
 
 Max 1 worker per iteration.
 
@@ -210,7 +210,7 @@ Max 1 worker per iteration.
 
 If `TARGET_PRESET != ACTIVE_PRESET`:
 1. `CronDelete` old job → `CronCreate` new with matching expression
-2. `kvido skills/heartbeat/heartbeat-state.sh set cron_job_id` + `active_preset`
+2. `kvido heartbeat-state set cron_job_id` + `active_preset`
 3. Log: `- **HH:MM** [heartbeat] Adaptive: {ACTIVE} -> {TARGET}`
 
 ---
@@ -221,11 +221,11 @@ If `TARGET_PRESET != ACTIVE_PRESET`:
 |---------|-----|
 | Passing message `ts` as `THREAD_TS` | `THREAD_TS` = `thread_ts` field (parent), never `ts` (message itself) |
 | Dispatching chat-agent for trivial messages ("ok", "thanks") | Classify first — greetings, acks, sleep/turbo/cancel are always inline |
-| Sending Slack directly from agents | Only heartbeat calls `kvido skills/slack/slack.sh`. Agents return NL output. |
+| Sending Slack directly from agents | Only heartbeat calls `kvido slack`. Agents return NL output. |
 | Dispatching worker when one is already `in_progress` | Check TodoRead for `worker:*` in_progress first |
 | Forgetting to mark orphaned tasks on recovery | All `in_progress` tasks from previous session must be cleaned up in Step 1 |
 | Outputting verbose text when nothing happened | Silent exit is default. No output = nothing to report. |
-| Not updating `last_chat_ts` after processing | Always `kvido skills/heartbeat/heartbeat-state.sh set last_chat_ts` after chat handling |
+| Not updating `last_chat_ts` after processing | Always `kvido heartbeat-state set last_chat_ts` after chat handling |
 
 ## Critical Rules
 
@@ -236,5 +236,5 @@ If `TARGET_PRESET != ACTIVE_PRESET`:
 - **Max 1 worker per iteration.** Planner + 1 worker + 1 chat-agent is maximum.
 - **TodoWrite is the single source of truth** for dispatch tracking. No file-based locks.
 - **Dependency rule:** Do not dispatch chat-agent if one is already `in_progress`. Do not dispatch worker if one is already `in_progress`. Planner can run alongside chat-agent but not alongside another planner.
-- **No business agent calls `kvido skills/slack/slack.sh` directly.** Heartbeat owns Slack delivery.
+- **No business agent calls `kvido slack` directly.** Heartbeat owns Slack delivery.
 - **Notify TODOs are ephemeral.** Completed notify TODOs can be cleaned up after logging.

--- a/plugins/kvido/skills/interests/SKILL.md
+++ b/plugins/kvido/skills/interests/SKILL.md
@@ -21,7 +21,7 @@ Read `.claude/kvido.local.md`. For each topic where it is time to check (based o
 2. Compare with previous state in `state/interests.md`
 3. If new relevant info → create a triage task:
    ```bash
-   kvido skills/worker/task.sh create \
+   kvido task create \
      --title "[INTERESTS] description" \
      --instruction "description of finding" \
      --source interests \
@@ -39,7 +39,7 @@ for d in state/tasks/*/; do
   for f in "$d"*.md; do
     [[ -f "$f" ]] || continue
     SLUG=$(basename "$f" .md)
-    kvido skills/worker/task.sh read "$SLUG" 2>/dev/null | grep '^TITLE=' | cut -d= -f2-
+    kvido task read "$SLUG" 2>/dev/null | grep '^TITLE=' | cut -d= -f2-
   done
 done | grep -i "<search term>"
 ```

--- a/plugins/kvido/skills/morning/SKILL.md
+++ b/plugins/kvido/skills/morning/SKILL.md
@@ -45,7 +45,7 @@ List files in `memory/journal/`. If any exist, read the most recent (highest dat
 
 Determine yesterday's date (YYYY-MM-DD).
 
-Run `kvido skills/discover-sources.sh` to find installed source plugins. For each discovered source, read its `skills/source-*/SKILL.md` from the install path and call the morning fetch command. Pass the date as a literal string (not command substitution).
+Run `kvido discover-sources` to find installed source plugins. For each discovered source, read its `skills/source-*/SKILL.md` from the install path and call the morning fetch command. Pass the date as a literal string (not command substitution).
 
 If no source plugins are installed, skip to Step 3.
 
@@ -113,7 +113,7 @@ Be concise. Bullet points. No filler.
 
 Count triage tasks:
 ```bash
-kvido skills/worker/task.sh count triage
+kvido task count triage
 ```
 If > 0:
 > "X items in agent triage — run `/kvido:triage` to process."

--- a/plugins/kvido/skills/planner/SKILL.md
+++ b/plugins/kvido/skills/planner/SKILL.md
@@ -29,7 +29,7 @@ Go through `memory/planner.md`. Look for time triggers:
 - Format: `- HH:MM: <instruction>` or `- <day>: <instruction>`
 - If it's time to act and it hasn't been done today (check planner-state.md) → execute or create a worker task via:
   ```bash
-  skills/worker/task.sh create --instruction "<instruction>" --size s --priority high --source planner
+  kvido task create --instruction "<instruction>" --size s --priority high --source planner
   ```
 - Write to planner-state.md that the action was performed
 
@@ -44,7 +44,7 @@ If `memory/planner.md` does not exist → skip silently.
 Run the discovery script to find installed source plugins:
 
 ```bash
-kvido skills/discover-sources.sh
+kvido discover-sources
 ```
 
 Output: one line per installed source — `name<TAB>install_path`. If empty, no source plugins are installed — skip data gathering.
@@ -134,13 +134,13 @@ Dispatch: eod
 
 Load tasks in triage state:
 ```bash
-kvido skills/worker/task.sh list triage
+kvido task list triage
 ```
 
 **Triage items are NOT auto-approved.** They stay in `triage` until the user explicitly approves.
 
 For each task (max 3 per run):
-1. Read task detail: `kvido skills/worker/task.sh read <slug>` — understand what is requested
+1. Read task detail: `kvido task read <slug>` — understand what is requested
 2. Evaluate relevance and urgency
 3. **Clear request** → add to approval batch:
    - Suggest: title (max 8 words), priority, size, assignee=agent, brief description
@@ -176,7 +176,7 @@ Triage: <slug> '<title>' — <description>. Priority: <priority>. Size: <size>. 
 
 Also write a note on the task indicating the triage item was sent — but WITHOUT a Slack ts (heartbeat will fill that in after delivery):
 ```bash
-kvido skills/worker/task.sh note <slug> "Triage: sent for approval. Awaiting user decision."
+kvido task note <slug> "Triage: sent for approval. Awaiting user decision."
 ```
 
 **Note:** Planner runs as a subagent and does NOT have access to TodoWrite. Heartbeat (main session) will create `triage:<slug>` todo tasks for polling after delivery via `slack.sh`. Planner only writes notes on tasks and returns NL output.

--- a/plugins/kvido/skills/slack/SKILL.md
+++ b/plugins/kvido/skills/slack/SKILL.md
@@ -23,25 +23,25 @@ Heartbeat decides whether to send a message immediately, batch it, or just log i
 ### Send a message
 
 ```bash
-kvido skills/slack/slack.sh send <channel> <template> [--var key=value]...
+kvido slack send <channel> <template> [--var key=value]...
 ```
 
 ### Reply to a thread
 
 ```bash
-kvido skills/slack/slack.sh reply <channel> <thread_ts> <template> [--var key=value]...
+kvido slack reply <channel> <thread_ts> <template> [--var key=value]...
 ```
 
 ### Edit a message
 
 ```bash
-kvido skills/slack/slack.sh edit <channel> <message_ts> <template> [--var key=value]...
+kvido slack edit <channel> <message_ts> <template> [--var key=value]...
 ```
 
 ### Read messages
 
 ```bash
-kvido skills/slack/slack.sh read <channel> [--limit N] [--oldest ts] [--thread ts]
+kvido slack read <channel> [--limit N] [--oldest ts] [--thread ts]
 ```
 
 Without `--thread`: reads channel history (`conversations.history`).
@@ -50,7 +50,7 @@ With `--thread <ts>`: reads replies in the given thread (`conversations.replies`
 ### Delete a message
 
 ```bash
-kvido skills/slack/slack.sh delete <channel> <message_ts>
+kvido slack delete <channel> <message_ts>
 ```
 
 ## Templates

--- a/plugins/kvido/skills/triage/SKILL.md
+++ b/plugins/kvido/skills/triage/SKILL.md
@@ -19,7 +19,7 @@ Tone and style per `memory/persona.md` (Triage section). If persona does not exi
 Load the list of tasks in triage:
 
 ```bash
-kvido skills/worker/task.sh list triage
+kvido task list triage
 ```
 
 If no tasks: "Triage inbox is empty ✓" and stop.
@@ -28,7 +28,7 @@ For each task display:
 
 ```bash
 # For each slug from the listing:
-kvido skills/worker/task.sh read <slug>
+kvido task read <slug>
 ```
 
 ```
@@ -38,9 +38,9 @@ kvido skills/worker/task.sh read <slug>
 ```
 
 Wait for a response. Then:
-- `yes` → approve and move to todo: `kvido skills/worker/task.sh move <slug> todo`
-- `later` → add a note: `kvido skills/worker/task.sh note <slug> "deferred: YYYY-MM-DD"`, leave in triage
-- `no` → cancel: `kvido skills/worker/task.sh note <slug> "Rejected by user" && skills/worker/task.sh move <slug> cancelled`
+- `yes` → approve and move to todo: `kvido task move <slug> todo`
+- `later` → add a note: `kvido task note <slug> "deferred: YYYY-MM-DD"`, leave in triage
+- `no` → cancel: `kvido task note <slug> "Rejected by user" && kvido task move <slug> cancelled`
 
 After processing all: "Triage done: X accepted, Y deferred, Z discarded."
 
@@ -50,8 +50,8 @@ Worker automatically enforces the WIP limit for in-progress tasks.
 
 Get current WIP:
 ```bash
-kvido skills/worker/task.sh count in-progress
+kvido task count in-progress
 ```
 If >= 3: "WIP limit of 3 reached. What should be paused or completed?"
 
-Tasks with "waiting_on" in frontmatter do not count toward the limit — check via `kvido skills/worker/task.sh read <slug>` and filter those with a non-empty WAITING_ON.
+Tasks with "waiting_on" in frontmatter do not count toward the limit — check via `kvido task read <slug>` and filter those with a non-empty WAITING_ON.

--- a/plugins/kvido/skills/worker/SKILL.md
+++ b/plugins/kvido/skills/worker/SKILL.md
@@ -8,7 +8,7 @@ description: Use when heartbeat dispatches the worker agent to execute a queued 
 # Worker Skill
 
 Worker executes assigned tasks asynchronously in the background of the heartbeat.
-All queue management goes through `skills/worker/task.sh`.
+All queue management goes through `kvido task`.
 Tasks are local markdown files in `state/tasks/` — status is the folder name, metadata is YAML frontmatter.
 
 ## Pipeline
@@ -84,7 +84,7 @@ source_ref: "1773933088.437"
 ### Cancel handling
 At the start of work, verify the task has not been cancelled/completed:
 ```bash
-STATUS=$(kvido skills/worker/task.sh find "$TASK_SLUG")
+STATUS=$(kvido task find "$TASK_SLUG")
 [[ "$STATUS" =~ ^(done|failed|cancelled)$ ]] && exit 0  # silent — cancel or race condition
 ```
 


### PR DESCRIPTION
## Summary

- Add auto-discovery to kvido CLI — short command names resolved from `skills/` directory
- `kvido task list todo` instead of `kvido skills/worker/task.sh list todo`
- Resolution order: `skills/$name.sh` → `skills/$name/$name.sh` → `skills/*/$name.sh`
- Full paths (`kvido skills/...`) still work for backward compatibility
- Updated all SKILL.md, agent, and command references to short form (15 files, ~60 substitutions)

### Command mapping

| Short | Full path |
|---|---|
| `kvido config` | `skills/config.sh` |
| `kvido discover-sources` | `skills/discover-sources.sh` |
| `kvido heartbeat` | `skills/heartbeat/heartbeat.sh` |
| `kvido heartbeat-state` | `skills/heartbeat/heartbeat-state.sh` |
| `kvido triage-poll` | `skills/heartbeat/triage-poll.sh` |
| `kvido slack` | `skills/slack/slack.sh` |
| `kvido task` | `skills/worker/task.sh` |

## Test plan

- [ ] `kvido --root` still works
- [ ] `kvido task list todo` resolves correctly
- [ ] `kvido config 'sources.gitlab.repos'` resolves correctly
- [ ] `kvido /kvido:morning` falls through to Claude launcher (not matched as script)
- [ ] `kvido skills/heartbeat/heartbeat.sh` backward compat still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)