### PR TITLE
fix: validate unresolved template variables in slack.sh

### DIFF
--- a/plugins/kvido/skills/slack/slack.sh
+++ b/plugins/kvido/skills/slack/slack.sh
@@ -114,15 +114,30 @@ build_blocks() {
       echo "Error: template '$template_name' not found at $template_file" >&2
       exit 1
     fi
+    local rendered
     if [[ ${#jq_args[@]} -eq 0 ]]; then
-      cat "$template_file"
+      rendered=$(cat "$template_file")
     else
-      jq "${jq_args[@]}" '
+      rendered=$(jq "${jq_args[@]}" '
         walk(if type == "string" then
           reduce ($ARGS.named | to_entries[]) as $e (.; gsub("{{" + $e.key + "}}"; $e.value))
         else . end)
-      ' "$template_file"
+      ' "$template_file")
     fi
+
+    # Validate: fail if any {{placeholder}} remains unresolved
+    local unresolved
+    unresolved=$(echo "$rendered" | jq -r '
+      [.. | strings | [capture("\\{\\{(?<var>[^}]+)\\}\\}"; "g")] | .[].var]
+      | unique | .[]
+    ' 2>/dev/null || true)
+    if [[ -n "$unresolved" ]]; then
+      echo "Error: template '$template_name' has unresolved variables: $(echo "$unresolved" | tr '\n' ', ' | sed 's/,$//')" >&2
+      echo "Hint: pass --var <name>=<value> for each variable" >&2
+      exit 1
+    fi
+
+    echo "$rendered"
   fi
 }
 


### PR DESCRIPTION
## Summary

Add validation to `slack.sh` `build_blocks()` — after template rendering, check if any `{{placeholder}}` remains unresolved. Fails with a clear error listing missing variables.

**Before:** Morning briefing silently sent raw `{{date}}`, `{{briefing}}` etc. to Slack.
**After:** `Error: template 'morning' has unresolved variables: briefing, date, deepwork_time, meeting_time, triage_count`

Templates are unchanged — the structured vars are correct, the bug was in the caller not passing them.

Closes #10

## Test plan

- [ ] `kvido slack send morning --var message="test"` → error with list of missing vars
- [ ] `kvido slack send morning --var date=... --var briefing=... --var triage_count=... --var meeting_time=... --var deepwork_time=...` → success
- [ ] `kvido slack send chat --var message="test"` → success (no unresolved vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)