### PR TITLE
fix: replace stale symlink with registry-based wrapper

### DIFF
--- a/plugins/kvido/commands/setup.md
+++ b/plugins/kvido/commands/setup.md
@@ -106,6 +106,12 @@ memory/
 
 If the project does not have a `CLAUDE.md`, copy `CLAUDE.md.template` from the plugin as a starting point.
 
+If `CLAUDE.md` exists, check for stale patterns that indicate an outdated version:
+- `.claude/skills/` paths (should be `kvido <command>`)
+- Unprefixed slash commands like `/heartbeat` (should be `/kvido:heartbeat`)
+
+If stale patterns are found, inform the user and offer to replace `CLAUDE.md` with the current `CLAUDE.md.template` from the plugin. Always ask before overwriting — the user may have custom additions.
+
 ### f) Shell alias
 
 Offer the user a shell alias for quick launching:

--- a/plugins/kvido/kvido
+++ b/plugins/kvido/kvido
@@ -61,8 +61,18 @@ case "${1:-}" in
     ;;
   --install)
     mkdir -p "$HOME/.local/bin"
-    ln -sf "$KVIDO_ROOT/kvido" "$HOME/.local/bin/kvido"
-    echo "Installed: ~/.local/bin/kvido -> $KVIDO_ROOT/kvido"
+    # Write a wrapper that resolves plugin path from registry at runtime.
+    # A symlink would go stale when the plugin version changes in cache.
+    cat > "$HOME/.local/bin/kvido" <<'WRAPPER'
+#!/usr/bin/env bash
+_P=$(jq -r '.plugins | to_entries[] | select(.key | startswith("kvido@")) | .value[0].installPath' "$HOME/.claude/plugins/installed_plugins.json" 2>/dev/null | head -1)
+if [[ -z "$_P" || "$_P" == "null" || ! -d "$_P" ]]; then
+  echo "ERROR: kvido plugin not found in registry" >&2; exit 1
+fi
+exec "$_P/kvido" "$@"
+WRAPPER
+    chmod +x "$HOME/.local/bin/kvido"
+    echo "Installed: ~/.local/bin/kvido (registry-based wrapper)"
     ;;
   skills/*|agents/*)
     # Script dispatch — resolve to plugin install path


### PR DESCRIPTION
## Summary

- **Critical fix:** `kvido --install` now creates a wrapper script instead of a symlink. The symlink went stale after plugin auto-updates (pointed to old cached version), causing `kvido heartbeat-state` etc. to fall through to Claude launcher instead of dispatching to the script.
- **Setup improvement:** `/kvido:setup` now detects outdated workspace `CLAUDE.md` (stale `.claude/skills/` paths, unprefixed `/heartbeat` commands) and offers to update it.

## Root cause

`~/.local/bin/kvido` was a symlink to `/cache/kvido/0.5.0/kvido`. After plugin update to 0.7.0, the symlink still pointed to 0.5.0 which lacked auto-resolve — so `kvido heartbeat-state set ...` launched Claude Code with the command as a prompt instead of dispatching to the script.

## Test plan

- [ ] `kvido --install` creates `~/.local/bin/kvido` as executable script (not symlink)
- [ ] `kvido --root` resolves current plugin version
- [ ] `kvido heartbeat-state get iteration_count` dispatches correctly
- [ ] `/kvido:setup` detects stale CLAUDE.md and offers update

🤖 Generated with [Claude Code](https://claude.com/claude-code)