### PR TITLE
fix: refresh kvido wrapper and support registry v2 discovery

### DIFF
--- a/plugins/kvido/CLAUDE.md
+++ b/plugins/kvido/CLAUDE.md
@@ -36,7 +36,7 @@ This repo is a Claude Code plugin marketplace. Each plugin is in `plugins/<name>
 
 The `kvido` dispatcher script (`plugins/kvido/kvido`) resolves the plugin install path from the Claude Code registry (`~/.claude/plugins/installed_plugins.json`) and dispatches to target scripts. Commands use short names (e.g. `kvido task`, `kvido slack`) — auto-resolved from `skills/`.
 
-Installation: `kvido --install` (symlinks to `~/.local/bin/kvido`). Done automatically by `/kvido:setup`.
+Installation: `kvido --install` (writes a registry-based wrapper to `~/.local/bin/kvido`). Done automatically by `/kvido:setup`.
 
 Usage:
 ```bash

--- a/plugins/kvido/commands/heartbeat.md
+++ b/plugins/kvido/commands/heartbeat.md
@@ -8,7 +8,8 @@ allowed-tools: Read, Glob, Grep, Bash, Write, Edit, Agent, CronCreate, CronList,
 Ensure `kvido` CLI is available. Run:
 
 ```bash
-kvido --root 2>/dev/null || $(jq -r '.plugins | to_entries[] | select(.key | startswith("kvido@")) | .value[0].installPath' ~/.claude/plugins/installed_plugins.json)/kvido --install
+KVIDO_ROOT=$(jq -r '.plugins | to_entries[] | select(.key | startswith("kvido@")) | .value[0].installPath' ~/.claude/plugins/installed_plugins.json)
+"$KVIDO_ROOT/kvido" --install
 ```
 
 ## Step 1: Set up cron (once per session only)

--- a/plugins/kvido/commands/setup.md
+++ b/plugins/kvido/commands/setup.md
@@ -14,14 +14,14 @@ Setup and self-healing command. Run on first launch, after plugin installation, 
 
 ### kvido CLI
 
-Install the `kvido` CLI wrapper to `~/.local/bin/`:
+Install or refresh the `kvido` CLI wrapper in `~/.local/bin/`:
 
 ```bash
-kvido --root 2>/dev/null && echo "OK: kvido CLI available" || {
-  KVIDO_ROOT=$(jq -r '.plugins | to_entries[] | select(.key | startswith("kvido@")) | .value[0].installPath' ~/.claude/plugins/installed_plugins.json)
-  bash "$KVIDO_ROOT/kvido" --install
-}
+KVIDO_ROOT=$(jq -r '.plugins | to_entries[] | select(.key | startswith("kvido@")) | .value[0].installPath' ~/.claude/plugins/installed_plugins.json)
+bash "$KVIDO_ROOT/kvido" --install
 ```
+
+This always refreshes `~/.local/bin/kvido` to a registry-based wrapper, which avoids stale symlinks after plugin upgrades.
 
 Verify `~/.local/bin` is in PATH. If not, inform the user.
 

--- a/plugins/kvido/kvido
+++ b/plugins/kvido/kvido
@@ -12,7 +12,7 @@
 #   kvido heartbeat-state set key value       # shortcut for skills/heartbeat/heartbeat-state.sh
 #   kvido config 'sources.gitlab.repos'       # shortcut for skills/config.sh
 #   kvido --root                              # print plugin root path
-#   kvido --install                           # symlink to ~/.local/bin/kvido
+#   kvido --install                           # install wrapper to ~/.local/bin/kvido
 #
 # Routing:
 #   --root / --install    → built-in commands

--- a/plugins/kvido/skills/discover-sources.sh
+++ b/plugins/kvido/skills/discover-sources.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # Discover installed kvido-* source plugins
 # Reads ~/.claude/plugins/installed_plugins.json
-# Expected schema: array of objects with .name (string) and .installPath (string)
+# Supports both registry schemas:
+#   - v2: {version: N, plugins: {"name@registry": [{installPath, ...}], ...}}
+#   - legacy: [{name, installPath, ...}, ...]
 #
 # Usage:
 #   discover-sources.sh                     → list all: "name\tinstall_path" per line
@@ -21,9 +23,34 @@ if [[ "${1:-}" == "--check" ]]; then
   # Accept both "gitlab" and "kvido-gitlab"
   local_name="${2#kvido-}"
   jq -e --arg name "kvido-${local_name}" \
-    '.[] | select(.name == $name) | .installPath' "$REGISTRY" >/dev/null 2>&1
+    'if type == "object" and has("plugins") then
+       .plugins
+       | to_entries[]
+       | select(.key | split("@")[0] == $name)
+       | .value[0].installPath
+     elif type == "array" then
+       .[]
+       | select(.name == $name)
+       | .installPath
+     else
+       empty
+     end' \
+    "$REGISTRY" >/dev/null 2>&1
   exit $?
 fi
 
-jq -r '.[] | select(.name | startswith("kvido-")) | select(.installPath) | "\(.name)\t\(.installPath)"' \
+jq -r 'if type == "object" and has("plugins") then
+    .plugins
+    | to_entries[]
+    | select(.key | split("@")[0] | startswith("kvido-"))
+    | select(.value[0].installPath)
+    | "\(.key | split("@")[0])\t\(.value[0].installPath)"
+  elif type == "array" then
+    .[]
+    | select(.name | startswith("kvido-"))
+    | select(.installPath)
+    | "\(.name)\t\(.installPath)"
+  else
+    empty
+  end' \
   "$REGISTRY"


### PR DESCRIPTION
## Summary
- always refresh ~/.local/bin/kvido to the registry-based wrapper during setup and heartbeat bootstrap
- update discover-sources.sh to support the current registry v2 schema and keep legacy array compatibility
- align docs/comments with the wrapper behavior

## Problem
After the auto-discovery change, running kvido short commands could appear to hang. The root cause was a stale ~/.local/bin/kvido symlink still pointing at an older launcher that did not dispatch short commands and fell through to launching claude. Separately, the installed plugin's discover-sources.sh still expected the old installed_plugins.json array schema, so discovery failed against the current registry format.

## Verification
- regenerated ~/.local/bin/kvido and verified short commands return immediately
- verified plugins/kvido/skills/discover-sources.sh lists installed sources
- verified --check gitlab and --check kvido-jira return success