### PR TITLE
fix: remove GitLab links from triage-item template

### DIFF
--- a/plugins/kvido/skills/heartbeat/SKILL.md
+++ b/plugins/kvido/skills/heartbeat/SKILL.md
@@ -107,7 +107,7 @@ Use `TodoRead` to list all existing tasks. If any `in_progress` tasks exist from
 
 ### Creating triage tasks
 
-Triage TODOs are created in Step 2c when heartbeat delivers a `triage-item` notification through `kvido slack`. The returned `ts` is written into `triage:<issue_id>` TODO description. No CHAT_MESSAGES scanning needed for triage creation.
+Triage TODOs are created in Step 2c when heartbeat delivers a `triage-item` notification through `kvido slack`. The returned `ts` is written into `triage:<slug>` TODO description. No CHAT_MESSAGES scanning needed for triage creation.
 
 ### Polling reactions
 

--- a/plugins/kvido/skills/slack/SKILL.md
+++ b/plugins/kvido/skills/slack/SKILL.md
@@ -63,7 +63,7 @@ In `templates/` — JSON files with `{{placeholder}}` variables. Unified format:
 | `eod` | 🌙 | `date`, `summary`, `session_time`, `done_count`, `open_count` | EOD summary |
 | `event` | (custom `{{emoji}}`) | `emoji`, `title`, `description`, `source`, `reference`, `timestamp` | Planner notifications, heartbeat events |
 | `worker-report` | 🔧 | `title`, `results`, `task_id`, `duration` | Worker task completion |
-| `triage-item` | 📋 | `issue`, `title`, `description`, `priority`, `size`, `assignee`, `issue_url` | Individual triage item |
+| `triage-item` | 📋 | `slug`, `title`, `description`, `priority`, `size`, `assignee` | Individual triage item |
 | `maintenance` | 🔧 | `librarian`, `enricher`, `self_improver`, `health`, `timestamp` | Maintenance summary |
 | `chat` | 💬 | `message` | General messages, chat replies |
 

--- a/plugins/kvido/skills/slack/templates/triage-item.json
+++ b/plugins/kvido/skills/slack/templates/triage-item.json
@@ -1,5 +1,5 @@
 [
-  {"type":"section","text":{"type":"mrkdwn","text":"📋 *Triage #{{issue}}* — {{title}}\n{{description}}\n<{{issue_url}}|GitLab #{{issue}}>"}},
+  {"type":"section","text":{"type":"mrkdwn","text":"📋 *Triage #{{slug}}* — {{title}}\n{{description}}"}},
   {"type":"context","elements":[
     {"type":"mrkdwn","text":"{{priority}} · {{size}} · {{assignee}} · reply ✅ approve / ❌ reject"}
   ]}


### PR DESCRIPTION
## Summary

- Remove `issue_url` variable and GitLab link from `triage-item.json` template — tasks are now local files in `state/tasks/`, not GitLab issues
- Rename `issue` → `slug` across triage-item template, slack SKILL.md docs, and heartbeat SKILL.md
- Prevents broken/empty links for agent-generated triage items that were never GitLab issues

## Changed files

- `plugins/kvido/skills/slack/templates/triage-item.json`
- `plugins/kvido/skills/slack/SKILL.md`
- `plugins/kvido/skills/heartbeat/SKILL.md`

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)