### PR TITLE
fix: dashboard body section truncation and script escape

### DIFF
--- a/plugins/kvido/skills/heartbeat/generate-dashboard.sh
+++ b/plugins/kvido/skills/heartbeat/generate-dashboard.sh
@@ -179,8 +179,8 @@ _read_fm() {
 
 _read_body_section() {
   local file="$1" section="$2"
+  # Read everything after the section header until EOF (no early stop on nested ##)
   awk -v s="## $section" '
-    found && /^## / { exit }
     found { print }
     $0 == s { found=1 }
   ' "$file"
@@ -249,8 +249,8 @@ if [[ -d "$TASKS_DIR" ]]; then
     done
   done
   if [[ ${#TASK_ENTRIES[@]} -gt 0 ]]; then
-    # Escape </script> sequences to prevent breaking the <script> tag
-    TASKS_JSON=$(printf '%s\n' "${TASK_ENTRIES[@]}" | jq -s '.' | sed 's/<\/script>/<\\\/script>/g')
+    # Escape </script> sequences (case-insensitive) to prevent breaking the <script> tag
+    TASKS_JSON=$(printf '%s\n' "${TASK_ENTRIES[@]}" | jq -s '.' | sed 's/<\/[sS][cC][rR][iI][pP][tT]>/<\\\/script>/gi')
   fi
 fi
 


### PR DESCRIPTION
## Summary

Fixes from Codex code review on the task dashboard:

- **`_read_body_section` truncation** — awk stopped at any `## ` heading inside task instruction/worker notes, truncating multi-section tasks. Now reads until EOF.
- **`</script>` escape** — only matched lowercase, but HTML end tags are case-insensitive. Mixed-case `</SCRIPT>` or `</Script>` in task content could terminate the script tag early. Now uses case-insensitive regex.

## Test plan

- [ ] Task with nested `## Acceptance criteria` heading renders fully in detail view
- [ ] Task content containing `</Script>` doesn't break the dashboard page
- [ ] `bash -n generate-dashboard.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)