### PR TITLE
fix(setup): skip shell alias offer when kvido is already in PATH

### DIFF
--- a/plugins/kvido/commands/setup.md
+++ b/plugins/kvido/commands/setup.md
@@ -101,7 +101,17 @@ Read `$KVIDO_HOME/.env`. If it contains empty values (keys with `=""` or `=`):
 
 ### d) Shell alias
 
-Offer the user a shell alias for quick launching:
+Check whether `kvido` CLI is already accessible:
+
+```bash
+if command -v kvido &>/dev/null && kvido --help &>/dev/null; then
+  echo "kvido already in PATH at $(command -v kvido) — skipping alias offer"
+fi
+```
+
+If `kvido` is already in PATH and `kvido --help` exits successfully, skip this step entirely — the alias would be redundant.
+
+Otherwise, offer the user a shell alias for quick launching:
 
 1. Derive alias name from `memory/persona.md` assistant name (lowercase, strip diacritics via `iconv -f utf-8 -t ascii//TRANSLIT`). Fallback: `kvido`.
 2. Ask: "Do you want to create a shell alias `<name>` for quick launching?"


### PR DESCRIPTION
## Summary

- Step 1d in setup command now checks `command -v kvido && kvido --help` before offering the shell alias
- If kvido CLI is already installed in `~/.local/bin` (or anywhere in PATH), the alias step is skipped silently
- Alias is redundant when the CLI binary is already accessible directly

Closes #37

## Test plan

- [ ] Fresh install: kvido not in PATH → alias offer still appears as before
- [ ] After `kvido --install`: kvido in PATH → alias step is skipped without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)