### PR TITLE
feat: set CLAUDE_AUTOCOMPACT_PCT_OVERRIDE at session start

### DIFF
--- a/plugins/kvido/kvido
+++ b/plugins/kvido/kvido
@@ -80,6 +80,14 @@ _exec_claude_prompt() {
   # Assembly hook — generate session context (non-fatal)
   KVIDO_PROJECT="$PWD" bash "$KVIDO_ROOT/hooks/pre-session.sh" 2>/dev/null || true
 
+  # CLAUDE_AUTOCOMPACT_PCT_OVERRIDE — set from config if not already in environment
+  if [[ -z "${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-}" ]]; then
+    _autocompact_pct=$(bash "$KVIDO_ROOT/skills/config.sh" 'skills.session.autocompact_pct' '50' 2>/dev/null || echo '50')
+    if [[ "$_autocompact_pct" != "0" && -n "$_autocompact_pct" ]]; then
+      export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="$_autocompact_pct"
+    fi
+  fi
+
   exec claude "${args[@]}" "$prompt"
 }
 

--- a/plugins/kvido/kvido.local.md.example
+++ b/plugins/kvido/kvido.local.md.example
@@ -160,6 +160,12 @@ skills.daily_questions.enabled: true
 skills.daily_questions.max_questions: 2
 skills.daily_questions.frequency: weekdays
 
+# Session ---
+# autocompact_pct: context-window fill percentage at which Claude auto-compacts.
+# Maps to CLAUDE_AUTOCOMPACT_PCT_OVERRIDE. Set to 0 to disable (let Claude use default).
+# Default: 50 (compact when context is 50% full).
+skills.session.autocompact_pct: 50
+
 # Self-improver ---
 # github_issues.enabled: whether self-improver may create GitHub issues on
 #   the kvido plugin repo for detected plugin-level improvement proposals.


### PR DESCRIPTION
## Summary

- Reads `skills.session.autocompact_pct` from kvido config (default: `50`) at session start
- Exports `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` before launching Claude Code
- Setting value to `0` disables the override (Claude uses its own default)
- Existing env var in shell takes precedence (not overwritten)
- Added `skills.session.autocompact_pct` to `kvido.local.md.example` with documentation

Closes #45

## Test plan

- [ ] Launch `kvido` — verify `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50` is active in session
- [ ] Set `skills.session.autocompact_pct: 75` in kvido.local.md — verify value is picked up
- [ ] Set `skills.session.autocompact_pct: 0` — verify env var is NOT exported
- [ ] Pre-set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80` in shell — verify kvido does not overwrite it

🤖 Generated with [Claude Code](https://claude.com/claude-code)