### PR TITLE
fix(setup): remove shell alias step

### DIFF
--- a/plugins/kvido/commands/setup.md
+++ b/plugins/kvido/commands/setup.md
@@ -99,23 +99,7 @@ Read `$KVIDO_HOME/.env`. If it contains empty values (keys with `=""` or `=`):
 2. Offer help filling them in (how to find Slack IDs, where to get tokens, etc.)
 3. If the user provides values, write them to `.env`
 
-### d) Shell alias
-
-Offer the user a shell alias for quick launching:
-
-1. Derive alias name from `memory/persona.md` assistant name (lowercase, strip diacritics via `iconv -f utf-8 -t ascii//TRANSLIT`). Fallback: `kvido`.
-2. Ask: "Do you want to create a shell alias `<name>` for quick launching?"
-3. If yes:
-   - Detect shell rc file: if `$SHELL` contains `zsh` → `~/.zshrc`, else `~/.bashrc`
-   - Append to rc file (only if alias not already present):
-     ```bash
-     alias <name>='kvido'
-     ```
-   - Inform user: "Alias created. Run `source ~/.zshrc` (or `~/.bashrc`) or restart your shell to activate it."
-4. If no: skip silently.
-
-
-### e) Source plugin config validation
+### d) Source plugin config validation
 
 For each installed source plugin (via `kvido discover-sources`), verify that `kvido.local.md` contains the required config keys. Use `kvido config` to check.
 


### PR DESCRIPTION
## Summary

- Removes step 1d (Shell alias) from `plugins/kvido/commands/setup.md` entirely
- Aliases are no longer used — `kvido` CLI is installed directly via `kvido --install` into `~/.local/bin`
- Supersedes #44, which only added a PATH check before the alias offer — the step should not be offered at all

Closes #37

## Test plan

- [ ] Run `/kvido:setup` on fresh install — alias step no longer appears
- [ ] Steps a, b, c, d (source plugin config validation) flow correctly in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)