### PR TITLE
refactor: replace manual state/today.md writes with kvido log add

### DIFF
--- a/plugins/kvido-calendar/skills/source-calendar/SKILL.md
+++ b/plugins/kvido-calendar/skills/source-calendar/SKILL.md
@@ -24,13 +24,13 @@ Returns pre-categorized data per kvido.local.md `categories` + total meeting tim
 3. Format output: `- HH:MM–HH:MM — Summary [category]` per event, then total count
 
 ### watch
-If `state/today.md` contains Today's Schedule, use existing data.
+If `state/planner-state.md` contains a `## Today's Schedule` section (written by morning run), use existing data.
 Otherwise run `fetch.sh`. If it returns exit code 10, follow the MCP fallback from the fetch section above.
 Filter meetings starting in the next 60 min → reminder event.
 
 ## Schedule
-- morning: fetch (today)
+- morning: fetch (today), write schedule to `state/planner-state.md` section `## Today's Schedule`
 - heartbeat-quick: skip
 - heartbeat-full: watch (meetings in next 60 min)
 - heartbeat-maintenance: skip
-- eod: skip (data already in today.md)
+- eod: skip (schedule data already in planner-state.md)

--- a/plugins/kvido-slack/skills/source-slack/SKILL.md
+++ b/plugins/kvido-slack/skills/source-slack/SKILL.md
@@ -41,7 +41,7 @@ For new messages from other users (not from `SLACK_USER_ID`) determine notificat
 
 | Level | When | Action |
 |-------|------|--------|
-| `silent` | FYI, informational messages | Log: `- **HH:MM** [dm/<name>] <truncated text>` to `state/today.md` |
+| `silent` | FYI, informational messages | `kvido log add chat silent --message "[dm/<name>] <truncated text>"` |
 | `batch` | Less urgent, can wait | Return in NL output with `Event (batch):` prefix — heartbeat delivers at next full heartbeat |
 | `immediate` | Requires response — question, request, blocking someone | `slack.sh send event --var emoji="💬" --var title="DM from <name>" --var description="<text max 100 chars>" --var source="Slack DM" --var reference="open DM" --var timestamp="<HH:MM>"` |
 
@@ -75,11 +75,11 @@ Signals to report (desktop level):
 - User repeats the same question
 Report format: `[ds-parking/marvin] <description of issue or opportunity>`
 
-After analysis, write findings to `state/today.md` as a separate section `## Marvin QA`.
-If the section does not yet exist in today.md, append it at the end of the file.
-If it exists, append new findings below the existing section content.
-Format for each finding: `- **HH:MM** <description of issue or opportunity>`
-If no new findings were found, write nothing to today.md (silent output).
+After analysis, log each finding via:
+```bash
+kvido log add planner marvin-qa --message "<description of issue or opportunity>"
+```
+If no new findings were found, log nothing (silent output).
 
 ### triage-detect
 

--- a/plugins/kvido/commands/heartbeat.md
+++ b/plugins/kvido/commands/heartbeat.md
@@ -139,8 +139,8 @@ echo "$TRIAGE_JSON" | kvido triage-poll
 Output: `[{"slug":"fix-auth-bug","result":"approved|rejected|pending"},...]`
 
 For each result:
-- `approved` → log `- **HH:MM** [triage] <slug> approved -> todo`, mark `triage:<slug>` TODO completed
-- `rejected` → log `- **HH:MM** [triage] <slug> rejected -> cancelled`, mark TODO completed
+- `approved` → `kvido log add triage approved --message "<slug> approved -> todo"`, mark `triage:<slug>` TODO completed
+- `rejected` → `kvido log add triage rejected --message "<slug> rejected -> cancelled"`, mark TODO completed
 - `pending` → skip
 
 ---
@@ -223,7 +223,7 @@ Max 1 worker per iteration.
 If `TARGET_PRESET != ACTIVE_PRESET`:
 1. `CronDelete` old job → `CronCreate` new with matching expression
 2. `kvido heartbeat-state set cron_job_id` + `active_preset`
-3. Log: `- **HH:MM** [heartbeat] Adaptive: {ACTIVE} -> {TARGET}`
+3. `kvido log add heartbeat adaptive --message "interval {ACTIVE} -> {TARGET}"`
 
 ---
 


### PR DESCRIPTION
## Summary

- **skills/heartbeat/SKILL.md**: triage polling results (`approved`/`rejected`) and adaptive interval changes now use `kvido log add` instead of inline markdown log lines like `- **HH:MM** [triage] ...`
- **kvido-slack/source-slack/SKILL.md**: `silent` DM level and Marvin QA channel findings now logged via `kvido log add chat silent` / `kvido log add planner marvin-qa` instead of being written to `state/today.md`
- **kvido-calendar/source-calendar/SKILL.md**: `watch` capability now reads cached schedule from `state/planner-state.md` (written at morning run) instead of `state/today.md`; schedule entries added to morning fetch description accordingly

Dashboard (`generate-dashboard.sh`) is unaffected — it already reads exclusively from `kvido log list`.

Closes #39

## Test plan

- [ ] Heartbeat triage polling: approve/reject a triage item — verify `kvido log list --today` shows `triage approved` / `triage rejected` entry
- [ ] Heartbeat adaptive interval: trigger interval switch — verify `kvido log list --today` shows `heartbeat adaptive` entry
- [ ] Source-slack silent DM: receive FYI DM — verify `kvido log list --today` shows `chat silent` entry instead of today.md modification
- [ ] Source-calendar watch: run heartbeat-full after morning — verify schedule is read from planner-state.md
- [ ] Dashboard: open dashboard — verify timeline renders correctly from kvido log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)