### PR TITLE
fix(slack): enforce single-owner delivery contract across plugins

### DIFF
--- a/plugins/kvido-slack/skills/source-slack/SKILL.md
+++ b/plugins/kvido-slack/skills/source-slack/SKILL.md
@@ -43,7 +43,7 @@ For new messages from other users (not from `SLACK_USER_ID`) determine notificat
 |-------|------|--------|
 | `silent` | FYI, informational messages | `kvido log add chat silent --message "[dm/<name>] <truncated text>"` |
 | `batch` | Less urgent, can wait | Return in NL output with `Event (batch):` prefix — heartbeat delivers at next planner iteration |
-| `immediate` | Requires response — question, request, blocking someone | `kvido slack send event --var emoji="💬" --var title="DM from <name>" --var description="<text max 100 chars>" --var source="Slack DM" --var reference="open DM" --var timestamp="<HH:MM>"` |
+| `immediate` | Requires response — question, request, blocking someone | Return in NL output: `Event: 💬 DM from <name> — <text max 100 chars>. Source: Slack DM. Reference: open DM. Urgency: high.` |
 
 Decide based on context — who's writing, what they need, how urgent it is.
 

--- a/plugins/kvido/hooks/context-heartbeat.md
+++ b/plugins/kvido/hooks/context-heartbeat.md
@@ -1,5 +1,11 @@
 # Heartbeat Delivery Rules
 
+## Delivery Contract
+
+Heartbeat is the single owner of Slack message delivery. No agent, source plugin, or worker may call `kvido slack send|reply|edit` directly. They return structured NL output; heartbeat parses it and delivers according to the rules below.
+
+**Review check:** Any new source plugin or agent prompt must NOT contain `kvido slack send|reply|edit` calls. Verify before merge.
+
 ## Notification levels
 
 | Level | Behavior |


### PR DESCRIPTION
## Summary

- Remove direct `kvido slack send` instruction from `source-slack` SKILL.md `immediate` level — now returns structured NL output like all other agents/sources
- Add explicit **Delivery Contract** section to `context-heartbeat.md` as the canonical reference for the "heartbeat owns all Slack delivery" invariant
- Add review check reminder for new plugin/agent prompts

Closes #66

## Test plan

- [ ] Verify `source-slack` no longer contains any `kvido slack send|reply|edit` instructions
- [ ] Verify `context-heartbeat.md` includes the Delivery Contract section
- [ ] Run `grep -r 'kvido slack send' plugins/kvido-*/` to confirm no source plugin sends directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)