### PR TITLE
Use silent SessionStart context injection instead of systemMessage

### DIFF
--- a/plugins/kvido/hooks/session-start.sh
+++ b/plugins/kvido/hooks/session-start.sh
@@ -29,9 +29,12 @@ fi
 SESSION_CONTEXT="$(cat "$OUTPUT")"
 
 jq -n \
-  --arg msg "$SESSION_CONTEXT" \
+  --arg ctx "$SESSION_CONTEXT" \
   '{
     "continue": true,
     "suppressOutput": true,
-    "systemMessage": $msg
+    "hookSpecificOutput": {
+      "hookEventName": "SessionStart",
+      "additionalContext": $ctx
+    }
   }'


### PR DESCRIPTION
## Summary

- Switch `SessionStart` hook from `systemMessage` (visible in TUI) to `hookSpecificOutput.additionalContext` for silent pre-session context priming

Closes #81

## Test plan

- [ ] Start a kvido session (`KVIDO_SESSION=1`) and verify context is injected without appearing in the TUI
- [ ] Start a non-kvido session and verify hook still passes through cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)