### PR TITLE
fix: slack.sh edit returns exit code 0 on success

### DIFF
--- a/plugins/kvido/skills/slack/slack.sh
+++ b/plugins/kvido/skills/slack/slack.sh
@@ -79,7 +79,7 @@ slack_message() {
     echo "Error: $(echo "$result" | jq -r '.error')" >&2
     exit 1
   fi
-  [[ "$return_ts" == "true" ]] && echo "$result" | jq -r '.ts'
+  [[ "$return_ts" == "true" ]] && echo "$result" | jq -r '.ts' || true
 }
 
 # Parse --var arguments and render template through jq


### PR DESCRIPTION
## Summary

- Fix `slack_message()` returning exit code 1 when `return_ts="false"` (used by `edit` and `delete` actions)
- Add `|| true` to prevent `[[ ]]` test failure from propagating as function exit code
- Heartbeat delivery rules will now correctly treat successful edits as successes

Closes #84

## Test plan

- [ ] Verify `kvido slack edit <ts> <template> --var ...` returns exit code 0 on success
- [ ] Verify `kvido slack send` still returns the message timestamp
- [ ] Verify `kvido slack delete` also returns exit code 0 on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)