### PR TITLE
fix: convert \n escape sequences in slack.sh --var values to actual newlines

### DIFF
--- a/plugins/kvido/skills/slack/slack.sh
+++ b/plugins/kvido/skills/slack/slack.sh
@@ -97,6 +97,8 @@ build_blocks() {
         fi
         local key="${2%%=*}"
         local value="${2#*=}"
+        # Convert escaped \n sequences to actual newlines so Slack renders line breaks
+        value=$(printf '%b' "$value")
         jq_args+=(--arg "$key" "$value")
         shift 2
         ;;


### PR DESCRIPTION
## Summary

- When heartbeat (or any agent) sends a Slack message with `--var message="line1\nline2"`, the `\n` was passed as a literal backslash-n through jq `--arg`, so Slack rendered it as `\n` text instead of a line break.
- Fix: run each `--var` value through `printf '%b'` before handing it to jq, converting `\n` (and other standard escape sequences) to actual characters.
- The Slack API `chat.postMessage` `text` field requires actual newlines for line breaks.

## Test plan

- [ ] Send a Slack message with a `\n` in a `--var` value and verify it renders as a line break in Slack
- [ ] Confirm messages without `\n` in variables are unaffected
- [ ] Confirm block templates with multi-line variable values render correctly

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)