### PR TITLE
fix: replace JS auto-refresh with meta http-equiv for file:// compatibility

### DIFF
--- a/plugins/kvido/skills/heartbeat/generate-dashboard.sh
+++ b/plugins/kvido/skills/heartbeat/generate-dashboard.sh
@@ -318,6 +318,7 @@ cat > "$TMP_FILE" << 'HTMLEOF'
 HTMLEOF
 
 cat >> "$TMP_FILE" << HTMLEOF
+<meta http-equiv="refresh" content="${AUTO_REFRESH}">
 <title>Kvido Dashboard</title>
 HTMLEOF
 
@@ -972,15 +973,6 @@ document.querySelectorAll('.stat-val').forEach(function(el) {
 })();
 </script>
 JSEOF
-
-# Auto-refresh via JS (preserves hash, only refreshes on main view)
-cat >> "$TMP_FILE" << REFRESHEOF
-<script>
-setInterval(function() {
-  if (!location.hash || location.hash === '#') location.reload();
-}, ${AUTO_REFRESH}000);
-</script>
-REFRESHEOF
 
 cat >> "$TMP_FILE" << HTMLEOF
 <footer>auto-refresh ${AUTO_REFRESH}s</footer>


### PR DESCRIPTION
## Summary

- Replaces `setInterval`/`location.reload()` with `<meta http-equiv="refresh" content="N">` in the dashboard generator
- Fixes auto-refresh not working when the dashboard is opened via `file://` protocol (JS `location.reload()` is blocked by same-origin policy)
- The existing `route()` function already restores the active tab from `location.hash` on page load, so tab state is preserved after meta-refresh

## Test plan

- [ ] Open `~/.config/kvido/state/dashboard.html` via `file://` in a browser and confirm the page auto-refreshes every N seconds (default: 20)
- [ ] Confirm the active tab (tasks, log, etc.) is restored correctly after refresh
- [ ] Confirm auto-refresh still works when served over HTTP

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)