### PR TITLE
fix(kvido-calendar): update fetch.sh for new gws CLI API

### DIFF
--- a/plugins/kvido-calendar/skills/source-calendar/fetch.sh
+++ b/plugins/kvido-calendar/skills/source-calendar/fetch.sh
@@ -18,11 +18,9 @@ if ! command -v gws &>/dev/null; then
 fi
 
 # Fetch events
-EVENTS=$(gws calendar events list primary \
-  --timeMin "$TIME_MIN" \
-  --timeMax "$TIME_MAX" \
-  --singleEvents \
-  --orderBy startTime \
+PARAMS=$(printf '{"calendarId":"primary","timeMin":"%s","timeMax":"%s","singleEvents":true,"orderBy":"startTime"}' "$TIME_MIN" "$TIME_MAX")
+EVENTS=$(gws calendar events list \
+  --params "$PARAMS" \
   --format json 2>/dev/null) || {
   echo "ERROR: gws calendar fetch failed" >&2
   exit 1


### PR DESCRIPTION
## Summary

- `gws` CLI changed its API and no longer accepts positional `calendarId` argument or individual query flags (`--timeMin`, `--timeMax`, `--singleEvents`, `--orderBy`)
- All parameters must now be passed as a single JSON object via `--params`
- Updated `fetch.sh` to build a `--params` JSON string and use the new syntax

## Test plan

- [x] Ran `gws calendar events list --help` to confirm new syntax
- [x] Tested fixed script against today's calendar — returns events correctly
- [x] Verified `gws schema calendar.events.list` shows `calendarId` still accepted inside params JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)