### PR TITLE
feat: escalate source fetch errors to user via Slack notification

### DIFF
--- a/plugins/kvido-calendar/skills/source-calendar/fetch.sh
+++ b/plugins/kvido-calendar/skills/source-calendar/fetch.sh
@@ -24,7 +24,7 @@ EVENTS=$(gws calendar events list primary \
   --singleEvents \
   --orderBy startTime \
   --format json 2>/dev/null) || {
-  echo "ERROR: gws calendar fetch failed" >&2
+  echo "ERROR: calendar: gws calendar fetch failed for $TARGET_DATE" >&2
   exit 1
 }
 

--- a/plugins/kvido-gitlab/skills/source-gitlab/fetch-activity.sh
+++ b/plugins/kvido-gitlab/skills/source-gitlab/fetch-activity.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 
 CONFIG="kvido config"
 
+if ! command -v git &>/dev/null; then
+  echo "ERROR: gitlab: git not available" >&2
+  exit 1
+fi
+
 DATE=""
 PRIORITY_FILTER=""
 

--- a/plugins/kvido-gitlab/skills/source-gitlab/fetch-mrs.sh
+++ b/plugins/kvido-gitlab/skills/source-gitlab/fetch-mrs.sh
@@ -12,6 +12,11 @@ set -euo pipefail
 
 CONFIG="kvido config"
 
+if ! command -v glab &>/dev/null; then
+  echo "ERROR: gitlab: glab CLI not available" >&2
+  exit 1
+fi
+
 PRIORITY_FILTER=""
 
 while [[ $# -gt 0 ]]; do

--- a/plugins/kvido-gmail/skills/source-gmail/fetch.sh
+++ b/plugins/kvido-gmail/skills/source-gmail/fetch.sh
@@ -26,7 +26,7 @@ MESSAGES=$(gws gmail users messages list --params "$(jq -n \
   --arg q "$WATCH_QUERY" \
   --argjson max "$MAX_RESULTS" \
   '{userId: "me", q: $q, maxResults: $max}')" 2>/dev/null) || {
-  echo "ERROR: gws gmail fetch failed" >&2
+  echo "ERROR: gmail: gws gmail messages list failed" >&2
   exit 1
 }
 

--- a/plugins/kvido-jira/skills/source-jira/fetch.sh
+++ b/plugins/kvido-jira/skills/source-jira/fetch.sh
@@ -38,7 +38,7 @@ for proj_key in $($CONFIG --keys 'sources.jira.projects'); do
 done
 
 if [[ ${#projects[@]} -eq 0 ]]; then
-  echo "ERROR: no projects found in config" >&2
+  echo "ERROR: jira: no projects found in config" >&2
   exit 1
 fi
 

--- a/plugins/kvido-sessions/skills/source-sessions/fetch-messages.sh
+++ b/plugins/kvido-sessions/skills/source-sessions/fetch-messages.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 TARGET_DATE="${1:-$(date '+%Y-%m-%d')}"
 
 if ! date -d "$TARGET_DATE" &>/dev/null 2>&1; then
-  echo "ERROR: invalid date: $TARGET_DATE" >&2
+  echo "ERROR: sessions: invalid date: $TARGET_DATE" >&2
   exit 1
 fi
 

--- a/plugins/kvido-sessions/skills/source-sessions/fetch.sh
+++ b/plugins/kvido-sessions/skills/source-sessions/fetch.sh
@@ -24,7 +24,7 @@ TARGET_DATE="${1:-$(date -d 'yesterday' '+%Y-%m-%d')}"
 
 # Validate date format
 if ! date -d "$TARGET_DATE" &>/dev/null 2>&1; then
-  echo "ERROR: invalid date: $TARGET_DATE" >&2
+  echo "ERROR: sessions: invalid date: $TARGET_DATE" >&2
   exit 1
 fi
 

--- a/plugins/kvido/skills/planner/SKILL.md
+++ b/plugins/kvido/skills/planner/SKILL.md
@@ -59,6 +59,24 @@ For each discovered source plugin, read its `skills/source-*/SKILL.md` from the 
 
 Each source SKILL.md defines its own fetch commands and capabilities. Read it and follow its instructions.
 
+### Fetch error handling
+
+When running a fetch script, capture both stdout and stderr, and check the exit code:
+
+- **Exit code 0** — success, use output normally.
+- **Exit code 10** — CLI tool not available, follow MCP fallback instructions in the source SKILL.md. This is NOT an error.
+- **Any other non-zero exit code** — fetch failure. Emit an `Event:` line for heartbeat delivery:
+
+```
+Event: :warning: <source-name> fetch failed — <error message from stderr>. Source: <source-name>. Reference: none. Urgency: normal. Severity: :large_yellow_circle:.
+```
+
+Use dedup key `fetch-error:<source-name>` and check/record via `kvido planner-state event check/report` to avoid repeated alerts.
+
+Log the failure: `kvido log add planner error --message "fetch failed: <source-name>: <stderr>"`.
+
+Continue processing remaining sources — a single source failure must not abort the planner run.
+
 ### Non-source data
 
 | Source | Command | When |
@@ -265,5 +283,5 @@ If no notifications are needed, return: `No notifications.`
 - **Max 3 triage items per run.** Don't get bogged down.
 - **Time from system.** `date -Iseconds`.
 - **Always include URLs.** Add a full clickable URL to every MR, Jira issue.
-- **If a source fails** → log warning, continue with next source.
+- **If a source fails** (non-zero, non-10 exit) → emit `Event:` with `:warning:` severity, log via `kvido log add`, dedup via `kvido planner-state event check/report`, continue with next source. Exit code 10 = MCP fallback, not an error.
 - **Don't try to do the work yourself** — create a worker task.


### PR DESCRIPTION
## Summary

- Source fetch scripts now output structured errors on stderr in format `ERROR: <source-name>: <description>` when they fail (exit 1)
- `planner/SKILL.md` gets a new **Fetch error handling** section in Step 3 that instructs the planner to: capture stderr, check exit code, emit `Event:` lines for non-zero non-10 failures, dedup via `kvido planner-state event check/report`, and log via `kvido log add`
- Exit code 10 (CLI not available → MCP fallback) is explicitly excluded from error escalation
- Critical Rules updated to clarify exit-code-10 vs real errors

**Scripts updated:**
- `kvido-gitlab/fetch-mrs.sh` — added glab availability check
- `kvido-gitlab/fetch-activity.sh` — added git availability check  
- `kvido-calendar/fetch.sh` — standardized error prefix to `ERROR: calendar:`
- `kvido-gmail/fetch.sh` — standardized error prefix to `ERROR: gmail:`
- `kvido-jira/fetch.sh` — standardized error prefix to `ERROR: jira:`
- `kvido-sessions/fetch.sh` + `fetch-messages.sh` — standardized error prefix to `ERROR: sessions:`

## Test plan

- [ ] Manually break a fetch script (e.g. pass bad glab credentials) and confirm planner emits `Event: :warning: <source> fetch failed` in its output
- [ ] Confirm exit code 10 (gws/acli not available) does NOT generate an error Event
- [ ] Confirm dedup: same fetch error is not reported twice in consecutive planner runs
- [ ] Run `/kvido:setup` health check to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)