### PR TITLE
feat(planner): autonomous morning briefing at 6:30 on weekdays

### DIFF
--- a/plugins/kvido/hooks/context-heartbeat.md
+++ b/plugins/kvido/hooks/context-heartbeat.md
@@ -60,6 +60,28 @@ Chat-agent uses ack reactions only (see Chat ack lifecycle above), not status ed
 | Agent | Template | Level | Notes |
 |-------|----------|-------|-------|
 | chat-agent | chat | always immediate | Ack react before dispatch, unreact after delivery. After delivery, check pending chat tasks → dispatch next FIFO |
-| planner | per-line (Event/Triage/Reminder/Dispatch) | per delivery rules | Triage → create triage:<slug> TODO. Dispatch → dispatch named agent. |
+| planner | per-line (Event/Triage/Reminder/Dispatch/MorningBriefing) | per delivery rules | Triage → create triage:<slug> TODO. Dispatch → dispatch named agent. MorningBriefing → deliver via `morning` template (always immediate, standalone). |
 | worker | worker-report | high for error, else normal | — |
 | other | agent name as template, fallback event | per delivery rules | When falling back to `event` template, set `--var severity_bar=:large_yellow_circle:` as default if not provided by agent output |
+
+## MorningBriefing line parsing
+
+When planner output contains a `MorningBriefing:` line:
+
+```
+MorningBriefing: date=<YYYY-MM-DD> briefing=<text> triage_count=<N> meeting_time=<Xh> deepwork_time=<Yh>
+```
+
+Parse the fields and deliver:
+```bash
+kvido slack send dm morning \
+  --var date="<date>" \
+  --var briefing="<briefing>" \
+  --var triage_count="<N>" \
+  --var meeting_time="<Xh>" \
+  --var deepwork_time="<Yh>"
+```
+
+- Always immediate (never batched, never suppressed by focus mode)
+- Standalone — never threaded into digest
+- Deliver at most once per `MorningBriefing:` line per planner run

--- a/plugins/kvido/skills/planner/SKILL.md
+++ b/plugins/kvido/skills/planner/SKILL.md
@@ -35,6 +35,35 @@ If `memory/planner.md` does not exist → skip silently.
 
 ---
 
+## Step 2b: Autonomous Morning Briefing Check
+
+**Built-in default behavior — does not require `memory/planner.md`.** Runs on every planner invocation.
+
+> **Customization:** Users can override or extend morning briefing behavior in `memory/planner.md` under `## Scheduled Rules`. If a custom morning rule is present there, it takes precedence for content — but the trigger logic (time check + dedup) below still applies. `memory/planner.md` is the user customization layer; SKILL.md provides the guaranteed default.
+
+### Trigger conditions (ALL must be true)
+
+1. Current day is Mon–Fri (`date +%u` returns 1–5)
+2. Local hour is ≥ 6 and local hour < 12 (`date +%-H`)
+3. Local minute ≥ 30 when hour == 6 (`date +%-M`)
+4. `last_morning_date` not set today:
+   ```bash
+   kvido planner-state timestamp get last_morning_date
+   ```
+   Exit 1 = not yet sent today → proceed. Exit 0 with today's date → skip.
+
+### If triggered
+
+Set `MORNING_BRIEFING_DUE=true` — carry this flag through Steps 3–5.
+
+Proceed immediately to Step 3 (full data gather, all sources). The briefing is composed and delivered in Step 5a.
+
+### If not triggered
+
+Set `MORNING_BRIEFING_DUE=false` — skip morning briefing in Step 5a.
+
+---
+
 ## Step 3: Data Gathering
 
 ### Source discovery
@@ -110,14 +139,50 @@ Watch for stale MR reviews, WIP tickets with no activity, status changes. Decide
 
 ## Step 5: Scheduled Rules
 
+### 5a: Built-in morning briefing
+
+**If `MORNING_BRIEFING_DUE=true` (set in Step 2b):**
+
+Compose the morning briefing using data gathered in Step 3:
+
+1. Yesterday's summary — scan `memory/journal/` for yesterday's journal if available
+2. Overnight changes — highlight new events from sources (GitLab MRs, Jira tickets, Gmail, Slack threads)
+3. Today's calendar — list events from calendar source (start time, title)
+4. Triage count — `kvido task count triage`
+5. Focus recommendation — suggest what to focus on first based on priorities
+6. Deep work time estimate — estimate available focus blocks from calendar gaps
+
+Output the briefing as:
+```
+MorningBriefing: date=<YYYY-MM-DD> briefing=<full briefing text> triage_count=<N> meeting_time=<Xh> deepwork_time=<Yh>
+```
+
+Heartbeat parses `MorningBriefing:` and delivers it via `kvido slack send ... morning`.
+
+Track execution:
+```bash
+kvido planner-state timestamp set last_morning_date "$(date -Iseconds)"
+```
+
+Log:
+```bash
+kvido log add planner notify --message "Morning briefing sent"
+```
+
+**If `MORNING_BRIEFING_DUE=false`:** skip this section.
+
+### 5b: User-defined scheduled rules
+
 Read `memory/planner.md` section "## Scheduled Rules". For each rule:
 
 1. Evaluate trigger condition (time, day, "not yet today" via `kvido planner-state timestamp get <key>` — exit 1 means not done yet)
 2. If triggered:
    - Execute actions inline (gather data, create journal, dispatch librarian, etc.)
    - Compose output following the rule's delivery template
-   - Track execution: `kvido planner-state timestamp set <key> <value>` (e.g. key=last_morning_date, key=last_eod_date)
+   - Track execution: `kvido planner-state timestamp set <key> <value>` (e.g. key=last_eod_date)
 3. If not triggered: skip
+
+**Note:** `last_morning_date` is managed by Step 5a above — do not re-trigger a morning briefing from user-defined rules if `MORNING_BRIEFING_DUE=false`.
 
 Rules are user-defined natural language with structured triggers and actions. Interpret them flexibly. Default scheduled rules are provided by setup.
 


### PR DESCRIPTION
## Summary

- Adds Step 2b to `plugins/kvido/skills/planner/SKILL.md`: explicit built-in trigger that fires on Mon-Fri after 06:30, checks `last_morning_date` for dedup, and sets `MORNING_BRIEFING_DUE` flag
- Adds Step 5a: morning briefing composition from gathered sources, outputs `MorningBriefing:` line for heartbeat delivery
- Updates `plugins/kvido/hooks/context-heartbeat.md`: documents how heartbeat parses `MorningBriefing:` lines and delivers via `morning` template (always immediate, standalone, never batched)

The briefing fires without any user DM or message. It does not require `memory/planner.md` to exist.

## Test plan

- [ ] Verify planner runs at 06:30+ on a weekday and emits `MorningBriefing:` line
- [ ] Verify heartbeat delivers via `kvido slack send dm morning`
- [ ] Verify second planner run same day skips (last_morning_date set)
- [ ] Verify no briefing on weekends (Sat/Sun)
- [ ] Verify no briefing before 06:30

🤖 Generated with [Claude Code](https://claude.com/claude-code)