### PR TITLE
feat: add owl emoji favicon to dashboard

### DIFF
--- a/plugins/kvido/skills/heartbeat/generate-dashboard.sh
+++ b/plugins/kvido/skills/heartbeat/generate-dashboard.sh
@@ -318,6 +318,7 @@ HTMLEOF
 cat >> "$TMP_FILE" << HTMLEOF
 <meta http-equiv="refresh" content="${AUTO_REFRESH}">
 <title>Kvido Dashboard</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦉</text></svg>">
 HTMLEOF
 
 cat >> "$TMP_FILE" << 'HTMLEOF'


### PR DESCRIPTION
## Summary

- Adds a favicon to the generated `state/dashboard.html`
- Uses an owl emoji (🦉) as an SVG data URI — no external files needed
- Single line addition to the `<head>` section in `generate-dashboard.sh`

## Test plan

- [ ] Run `kvido dashboard` (or trigger heartbeat) and verify the browser tab shows the owl favicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)