### PR TITLE
fix: remove local keyword outside function in generate-dashboard.sh

### DIFF
--- a/plugins/kvido/skills/heartbeat/generate-dashboard.sh
+++ b/plugins/kvido/skills/heartbeat/generate-dashboard.sh
@@ -218,7 +218,6 @@ if [[ -d "$TASKS_DIR" ]]; then
       done
     fi
     for f in "${local_files[@]}"; do
-      local _base
       _base=$(basename "$f" .md)
       if [[ "$_base" =~ ^[0-9]+-(.+)$ ]]; then
         SLUG="${BASH_REMATCH[1]}"


### PR DESCRIPTION
## Summary

- Removes `local _base` declaration on the former line 221 of `generate-dashboard.sh`
- `local` is only valid inside bash functions; this line sits in a top-level `for` loop, causing bash to error out when the script runs with `set -euo pipefail`
- The variable `_base` does not need `local` here — plain assignment works correctly

Closes #125

## Test plan

- [ ] Run `bash -n plugins/kvido/skills/heartbeat/generate-dashboard.sh` — should produce no syntax errors
- [ ] Run the dashboard generation and confirm it completes without "local: can only be used in a function" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)