### PR TITLE
fix: replace meta refresh with JS location.reload() to preserve URL hash

### DIFF
--- a/plugins/kvido/skills/heartbeat/generate-dashboard.sh
+++ b/plugins/kvido/skills/heartbeat/generate-dashboard.sh
@@ -316,7 +316,6 @@ cat > "$TMP_FILE" << 'HTMLEOF'
 HTMLEOF
 
 cat >> "$TMP_FILE" << HTMLEOF
-<meta http-equiv="refresh" content="${AUTO_REFRESH}">
 <title>Kvido Dashboard</title>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦉</text></svg>">
 HTMLEOF
@@ -970,6 +969,15 @@ document.querySelectorAll('.stat-val').forEach(function(el) {
     btn.textContent = theme === 'dark' ? '\u2600' : '\u263E';
   });
 })();
+</script>
+JSEOF
+
+# Auto-refresh: use JS location.reload() so the URL hash (active tab) is preserved.
+# <meta http-equiv="refresh"> would strip the hash fragment on every reload.
+cat >> "$TMP_FILE" << JSEOF
+<script>
+// Auto-refresh every ${AUTO_REFRESH}s, preserving URL hash for active tab.
+setInterval(function() { location.reload(); }, ${AUTO_REFRESH} * 1000);
 </script>
 JSEOF
 


### PR DESCRIPTION
## Summary

- Removes `<meta http-equiv="refresh" content="...">` from the dashboard HTML
- Adds a `setInterval(() => location.reload(), N * 1000)` script block instead
- `location.reload()` preserves the URL hash fragment (active tab) natively; meta refresh does not
- Works with both `file://` and `http://` protocols

## Why

PR #110 switched from JS to meta refresh for `file://` compatibility, but `location.reload()` also works fine with `file://`. The meta refresh was causing the active tab (stored in the URL hash, e.g. `#tasks`) to be lost on every auto-refresh cycle.

## Test plan

- [ ] Generate dashboard (`kvido dashboard`)
- [ ] Navigate to a non-default tab (e.g. `#tasks`)
- [ ] Wait for auto-refresh interval — tab should remain active
- [ ] Verify generated HTML contains the `setInterval` script and no `meta http-equiv="refresh"`

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)