### PR TITLE
chore: replace silent || true with descriptive stderr logging

### DIFF
--- a/plugins/kvido-gitlab/skills/source-gitlab/fetch-mrs.sh
+++ b/plugins/kvido-gitlab/skills/source-gitlab/fetch-mrs.sh
@@ -73,12 +73,12 @@ process_repo() {
 
   if [[ "$authored_count" -gt 0 ]]; then
     echo "My MRs:"
-    echo "$authored" | jq -r '.[] | "  !\(.iid): \(if .draft then "DRAFT " else "" end)\(.title) [CI: \((.head_pipeline // {}).status // "no pipeline"), \(if .approved then "approved" elif (.reviewers // []) | length > 0 then "\(.reviewers | length) reviewer(s)" else "no reviewers" end)]"' 2>/dev/null || true
+    echo "$authored" | jq -r '.[] | "  !\(.iid): \(if .draft then "DRAFT " else "" end)\(.title) [CI: \((.head_pipeline // {}).status // "no pipeline"), \(if .approved then "approved" elif (.reviewers // []) | length > 0 then "\(.reviewers | length) reviewer(s)" else "no reviewers" end)]"' 2>/dev/null || echo "ERROR: failed to format authored MRs for $name (exit $?)" >&2
   fi
 
   if [[ "$reviewing_count" -gt 0 ]]; then
     echo "Reviewing:"
-    echo "$reviewing" | jq -r '.[] | "  !\(.iid): \(.title) (by \((.author // {}).username // "?")) [CI: \((.head_pipeline // {}).status // "no pipeline")]"' 2>/dev/null || true
+    echo "$reviewing" | jq -r '.[] | "  !\(.iid): \(.title) (by \((.author // {}).username // "?")) [CI: \((.head_pipeline // {}).status // "no pipeline")]"' 2>/dev/null || echo "ERROR: failed to format reviewing MRs for $name (exit $?)" >&2
   fi
 
   echo ""

--- a/plugins/kvido-jira/skills/source-jira/fetch.sh
+++ b/plugins/kvido-jira/skills/source-jira/fetch.sh
@@ -74,6 +74,7 @@ for i in "${!projects[@]}"; do
   }
 
   # Skip header, count lines
+  # grep -c outputs "0" and exits 1 when no matches — that is normal, not an error
   count=$(echo "$output" | tail -n +2 | grep -c . || true)
 
   if [[ "$count" -eq 0 ]]; then

--- a/plugins/kvido-sessions/skills/source-sessions/fetch-messages.sh
+++ b/plugins/kvido-sessions/skills/source-sessions/fetch-messages.sh
@@ -73,7 +73,7 @@ while IFS= read -r jsonl_file; do
       end
     else empty
     end
-  ' "$jsonl_file" 2>/dev/null || true)
+  ' "$jsonl_file" 2>/dev/null || echo "ERROR: session message extraction failed for $jsonl_file (exit $?)" >&2)
 
   if [[ -n "$messages" ]]; then
     session_id=$(basename "$jsonl_file" .jsonl)

--- a/plugins/kvido-sessions/skills/source-sessions/fetch.sh
+++ b/plugins/kvido-sessions/skills/source-sessions/fetch.sh
@@ -85,11 +85,13 @@ file_may_contain_date() {
   # First timestamp in file (skip lines without timestamp field)
   first_date=$(grep -m1 '"timestamp":"' "$file" 2>/dev/null \
     | grep -o '"timestamp":"[0-9-]*' | cut -c14- || true)
+    # grep returns exit 1 when no timestamps found — handled by empty check below
 
   # Last timestamp in file (scan last 20 lines — timestamp is usually at end of line)
   last_date=$(tail -20 "$file" 2>/dev/null \
     | grep '"timestamp":"' | tail -1 \
     | grep -o '"timestamp":"[0-9-]*' | cut -c14- || true)
+    # grep returns exit 1 when no timestamps found — handled by empty check below
 
   # No timestamps found — skip
   [[ -z "$first_date" && -z "$last_date" ]] && return 1
@@ -128,7 +130,7 @@ while IFS= read -r jsonl_file; do
     else
       "EP:" + $ep
     end
-  ' "$jsonl_file" 2>/dev/null || true)
+  ' "$jsonl_file" 2>/dev/null || echo "ERROR: session jq parsing failed for $jsonl_file (exit $?)" >&2)
 
   [[ -z "$jq_output" ]] && continue
 
@@ -164,7 +166,7 @@ while IFS= read -r jsonl_file; do
     echo "$jq_output" | grep '^TX:' | cut -c4- \
     | grep -oE '[A-Z]{2,10}-[0-9]{3,6}' \
     | sort -u | tr '\n' ',' | sed 's/,$//' \
-    || true
+    || true  # grep returns exit 1 when no tickets found — valid for non-Jira sessions
   )
 
   # Accumulate per project

--- a/plugins/kvido/hooks/build-context.sh
+++ b/plugins/kvido/hooks/build-context.sh
@@ -25,6 +25,7 @@ fi
 # State summary
 if [[ -f "$KVIDO_HOME/state/current.md" ]]; then
   FOCUS=$(grep -A1 "## Active Focus" "$KVIDO_HOME/state/current.md" 2>/dev/null | tail -1 || echo "")
+  # grep -c outputs "0" and exits 1 when no matches — valid for empty WIP section
   WIP_COUNT=$(sed -n '/## Work in Progress/,/## /p' "$KVIDO_HOME/state/current.md" 2>/dev/null | grep -c "^\- " 2>/dev/null || true)
   echo "## State"
   echo "- Focus: ${FOCUS:-none}"
@@ -44,4 +45,4 @@ fi
 echo ""
 
 # Plugin session context contributions
-bash "$PLUGIN_ROOT/skills/context/context.sh" session 2>/dev/null || true
+bash "$PLUGIN_ROOT/skills/context/context.sh" session 2>/dev/null || echo "ERROR: context.sh session failed (exit $?)" >&2

--- a/plugins/kvido/hooks/pre-compact.sh
+++ b/plugins/kvido/hooks/pre-compact.sh
@@ -14,7 +14,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 
-CONTEXT=$(KVIDO_PROJECT="$PROJECT_DIR" bash "$SCRIPT_DIR/build-context.sh" 2>/dev/null || true)
+CONTEXT=$(KVIDO_PROJECT="$PROJECT_DIR" bash "$SCRIPT_DIR/build-context.sh" 2>/dev/null || echo "ERROR: build-context.sh failed (exit $?)" >&2)
 
 if [[ -n "$CONTEXT" ]]; then
   jq -n --arg msg "$CONTEXT" \

--- a/plugins/kvido/hooks/session-start.sh
+++ b/plugins/kvido/hooks/session-start.sh
@@ -19,7 +19,7 @@ OUTPUT="$KVIDO_HOME/state/session-context.md"
 
 mkdir -p "$KVIDO_HOME/state"
 
-KVIDO_PROJECT="$PROJECT_DIR" bash "$SCRIPT_DIR/build-context.sh" > "$OUTPUT" 2>/dev/null || true
+KVIDO_PROJECT="$PROJECT_DIR" bash "$SCRIPT_DIR/build-context.sh" > "$OUTPUT" 2>/dev/null || echo "ERROR: build-context.sh failed (exit $?)" >&2
 
 if [[ ! -s "$OUTPUT" ]]; then
   jq -n '{"continue": true}'

--- a/plugins/kvido/skills/config.sh
+++ b/plugins/kvido/skills/config.sh
@@ -117,6 +117,7 @@ _list_keys() {
         echo "ERROR: Failed to list keys from config file: $CONFIG_FILE" >&2
         return 2
     }
+    # grep returns exit 1 when no matches — valid when all keys start with '_'
     echo "$raw" | grep -v '^_' || true
 }
 

--- a/plugins/kvido/skills/context/context.sh
+++ b/plugins/kvido/skills/context/context.sh
@@ -32,5 +32,5 @@ if [[ -x "$DISCOVER" ]]; then
       cat "$HOOK_FILE"
       echo ""
     fi
-  done < <(bash "$DISCOVER" 2>/dev/null || true)
+  done < <(bash "$DISCOVER" 2>/dev/null || echo "ERROR: discover-sources.sh failed (exit $?)" >&2)
 fi

--- a/plugins/kvido/skills/event/event.sh
+++ b/plugins/kvido/skills/event/event.sh
@@ -102,7 +102,7 @@ case "$CMD" in
         cutoff_ts="$(date -Iseconds -d "@$cutoff_epoch")"
         existing=$(jq -r --arg dk "$dedup_key" --arg ct "$cutoff_ts" \
           'select(.data.dedup_key == $dk and .ts >= $ct) | .id' \
-          "$EVENTS_FILE" 2>/dev/null | head -1 || true)
+          "$EVENTS_FILE" 2>/dev/null | head -1 || echo "ERROR: event dedup check failed (exit $?)" >&2)
         if [[ -n "$existing" ]]; then
           exit 2
         fi
@@ -213,6 +213,7 @@ case "$CMD" in
     _ensure_file
 
     if [[ -n "$through" ]]; then
+      # grep returns exit 1 when event ID not found — handled by empty check below
       line_num=$(grep -n "\"$through\"" "$EVENTS_FILE" | head -1 | cut -d: -f1 || true)
       if [[ -n "$line_num" ]]; then
         bash "$STATE_SH" set "${consumer}.cursor_offset" "$line_num"
@@ -261,7 +262,7 @@ case "$CMD" in
       before_count=$(wc -l < "$EVENTS_FILE" | tr -d ' ')
 
       tmp="$(mktemp "${EVENTS_FILE}.tmp.XXXXXX")"
-      jq -c --arg ct "$cutoff_ts" 'select(.ts >= $ct)' "$EVENTS_FILE" > "$tmp" 2>/dev/null || true
+      jq -c --arg ct "$cutoff_ts" 'select(.ts >= $ct)' "$EVENTS_FILE" > "$tmp" 2>/dev/null || echo "ERROR: event gc jq filter failed (exit $?)" >&2
       mv "$tmp" "$EVENTS_FILE"
 
       after_count=$(wc -l < "$EVENTS_FILE" | tr -d ' ')
@@ -269,6 +270,7 @@ case "$CMD" in
 
       # Adjust all cursor-like keys by subtracting removed lines (floor at 0)
       if [[ "$removed" -gt 0 ]]; then
+        # grep returns exit 1 when no cursor keys exist — valid for fresh installs
         for cursor_key in $(bash "$STATE_SH" list 2>/dev/null | grep -E '\.(cursor_offset|pending_cursor)$' || true); do
           old_val=$(bash "$STATE_SH" get "$cursor_key" 2>/dev/null || echo "0")
           [[ -z "$old_val" ]] && old_val=0

--- a/plugins/kvido/skills/heartbeat/generate-dashboard.sh
+++ b/plugins/kvido/skills/heartbeat/generate-dashboard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # generate-dashboard.sh — Generates state/dashboard.html from assistant state files.
-# Called from heartbeat.sh. Must never fail fatally (heartbeat calls with || true).
+# Called from heartbeat.sh. Must never fail fatally (heartbeat logs errors to stderr).
 #
 # Data sources:
 #   1. kvido log list (unified activity log)
@@ -155,7 +155,7 @@ fi
 # Source 4: Human-readable timeline from kvido log
 # ---------------------------------------------------------------------------
 TODAY_LOG_LINES=""
-TODAY_LOG_LINES=$(bash "$LOG_SH" list --today --format human --limit 50 2>/dev/null || true)
+TODAY_LOG_LINES=$(bash "$LOG_SH" list --today --format human --limit 50 2>/dev/null || echo "ERROR: log list failed (exit $?)" >&2)
 
 # ---------------------------------------------------------------------------
 # Source 5: Local task files (work queue counts)

--- a/plugins/kvido/skills/heartbeat/heartbeat.sh
+++ b/plugins/kvido/skills/heartbeat/heartbeat.sh
@@ -10,7 +10,7 @@ PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 KVIDO_HOME="${KVIDO_HOME:-$HOME/.config/kvido}"
 
 # Lazy migration — runs once if old state files exist
-kvido migrate 2>/dev/null || true
+kvido migrate 2>/dev/null || echo "ERROR: kvido migrate failed (exit $?)" >&2
 
 TIMESTAMP="$(date -Iseconds)"
 HOUR=$(date +%-H)
@@ -130,7 +130,7 @@ fi
 # 1. Try kvido config 'slack.user_id' (resolves $SLACK_USER_ID from .env)
 # 2. Fall back to $SLACK_USER_ID env var directly
 # 3. Fall back to cached value in state (heartbeat.owner_user_id)
-OWNER_USER_ID=$($CONFIG 'slack.user_id' '' 2>/dev/null || true)
+OWNER_USER_ID=$($CONFIG 'slack.user_id' '' 2>/dev/null || echo "ERROR: failed to read slack.user_id config (exit $?)" >&2)
 if [[ -z "$OWNER_USER_ID" || "$OWNER_USER_ID" == "null" ]]; then
   OWNER_USER_ID="${SLACK_USER_ID:-}"
 fi
@@ -185,10 +185,10 @@ fi
 kvido state increment heartbeat.iteration_count
 kvido state set heartbeat.last_heartbeat "$TIMESTAMP"
 
-# Dashboard generation (never fails heartbeat — || true)
+# Dashboard generation (non-fatal — log errors to stderr)
 DASH_ENABLED=$($CONFIG 'skills.dashboard.enabled' 'true')
 if [[ "$DASH_ENABLED" != "false" ]]; then
-  "$SCRIPT_DIR/generate-dashboard.sh" 2>/dev/null || true
+  "$SCRIPT_DIR/generate-dashboard.sh" 2>/dev/null || echo "ERROR: generate-dashboard.sh failed (exit $?)" >&2
 fi
 
 # Read pending dispatch events for heartbeat to process

--- a/plugins/kvido/skills/heartbeat/triage-poll.sh
+++ b/plugins/kvido/skills/heartbeat/triage-poll.sh
@@ -37,11 +37,11 @@ for i in $(seq 0 $((COUNT - 1))); do
   REJECTED=$(echo "$REACTIONS" | jq -r '.x // .thumbsdown // "false"')
 
   if [[ "$APPROVED" == "true" ]]; then
-    "$TASK_SH" move "$SLUG" todo >/dev/null 2>&1 || true
+    "$TASK_SH" move "$SLUG" todo >/dev/null 2>&1 || echo "ERROR: task move $SLUG to todo failed (exit $?)" >&2
     RESULTS=$(echo "$RESULTS" | jq --arg slug "$SLUG" '. + [{"slug": $slug, "result": "approved"}]')
   elif [[ "$REJECTED" == "true" ]]; then
-    "$TASK_SH" note "$SLUG" "## Cancelled\n\nRejected via triage reaction" >/dev/null 2>&1 || true
-    "$TASK_SH" move "$SLUG" cancelled >/dev/null 2>&1 || true
+    "$TASK_SH" note "$SLUG" "## Cancelled\n\nRejected via triage reaction" >/dev/null 2>&1 || echo "ERROR: task note $SLUG failed (exit $?)" >&2
+    "$TASK_SH" move "$SLUG" cancelled >/dev/null 2>&1 || echo "ERROR: task move $SLUG to cancelled failed (exit $?)" >&2
     RESULTS=$(echo "$RESULTS" | jq --arg slug "$SLUG" '. + [{"slug": $slug, "result": "rejected"}]')
   else
     RESULTS=$(echo "$RESULTS" | jq --arg slug "$SLUG" '. + [{"slug": $slug, "result": "pending"}]')

--- a/plugins/kvido/skills/log/log.sh
+++ b/plugins/kvido/skills/log/log.sh
@@ -222,7 +222,7 @@ case "$ACTION" in
 
     # Clean old archives (older than 7 days)
     if [[ "$ARCHIVE" == "true" ]]; then
-      find "${KVIDO_HOME}/state/archive" -name "log-*.jsonl" -mtime +7 -delete 2>/dev/null || true
+      find "${KVIDO_HOME}/state/archive" -name "log-*.jsonl" -mtime +7 -delete 2>/dev/null || echo "ERROR: failed to clean old log archives (exit $?)" >&2
     fi
     ;;
 

--- a/plugins/kvido/skills/migrate/migrate.sh
+++ b/plugins/kvido/skills/migrate/migrate.sh
@@ -48,13 +48,13 @@ if [[ -f "$OLD_PLANNER" ]]; then
   done
 
   # Migrate schedule (string)
-  schedule="$(jq -r '.schedule // empty' "$OLD_PLANNER" 2>/dev/null || true)"
+  schedule="$(jq -r '.schedule // empty' "$OLD_PLANNER" 2>/dev/null || echo "ERROR: failed to read schedule from planner.json (exit $?)" >&2)"
   if [[ -n "$schedule" ]]; then
     bash "$STATE_SH" set "planner.schedule" "$schedule"
   fi
 
   # Migrate last_run (JSON object → store as ISO timestamp if available)
-  last_run_ts="$(jq -r '.last_run.ts // .last_run.timestamp // empty' "$OLD_PLANNER" 2>/dev/null || true)"
+  last_run_ts="$(jq -r '.last_run.ts // .last_run.timestamp // empty' "$OLD_PLANNER" 2>/dev/null || echo "ERROR: failed to read last_run from planner.json (exit $?)" >&2)"
   if [[ -n "$last_run_ts" ]]; then
     bash "$STATE_SH" set "planner.last_run" "$last_run_ts"
   fi

--- a/plugins/kvido/skills/slack/slack.sh
+++ b/plugins/kvido/skills/slack/slack.sh
@@ -21,7 +21,7 @@ KVIDO_HOME="${KVIDO_HOME:-$HOME/.config/kvido}"
 TEMPLATES_DIR="$SCRIPT_DIR/templates"
 
 SLACK_API="https://slack.com/api"
-TOKEN=$(kvido config 'slack.bot_token' '' 2>/dev/null || true)
+TOKEN=$(kvido config 'slack.bot_token' '' 2>/dev/null || echo "ERROR: failed to read slack.bot_token config (exit $?)" >&2)
 
 if [[ -z "$TOKEN" ]]; then
   echo "Error: slack.bot_token not set in settings.json (use \"\$SLACK_BOT_TOKEN\" to reference .env)" >&2
@@ -29,7 +29,7 @@ if [[ -z "$TOKEN" ]]; then
 fi
 
 ACTION="${1:-}"
-shift || true
+shift || true  # shift may fail if no args; handled by case fallback below
 
 # If next arg looks like a Slack channel/DM ID (C.../D.../G...), consume it.
 # Otherwise fall back to slack.dm_channel_id from settings.json.
@@ -47,7 +47,7 @@ resolve_channel() {
   # 'dm' is a shorthand alias for the configured DM channel
   if [[ "${1:-}" == "dm" ]]; then
     if [[ -z "$_DEFAULT_CHANNEL" ]]; then
-      _DEFAULT_CHANNEL=$(kvido config 'slack.dm_channel_id' '' 2>/dev/null || true)
+      _DEFAULT_CHANNEL=$(kvido config 'slack.dm_channel_id' '' 2>/dev/null || echo "ERROR: failed to read slack.dm_channel_id config (exit $?)" >&2)
     fi
     if [[ -z "$_DEFAULT_CHANNEL" ]]; then
       echo "Error: channel not provided and slack.dm_channel_id not set in settings.json" >&2
@@ -58,7 +58,7 @@ resolve_channel() {
     return 0
   fi
   if [[ -z "$_DEFAULT_CHANNEL" ]]; then
-    _DEFAULT_CHANNEL=$(kvido config 'slack.dm_channel_id' '' 2>/dev/null || true)
+    _DEFAULT_CHANNEL=$(kvido config 'slack.dm_channel_id' '' 2>/dev/null || echo "ERROR: failed to read slack.dm_channel_id config (exit $?)" >&2)
   fi
   if [[ -z "$_DEFAULT_CHANNEL" ]]; then
     echo "Error: channel not provided and slack.dm_channel_id not set in settings.json" >&2
@@ -94,7 +94,9 @@ slack_message() {
     echo "Error: $(echo "$result" | jq -r '.error')" >&2
     exit 1
   fi
-  [[ "$return_ts" == "true" ]] && echo "$result" | jq -r '.ts' || true
+  if [[ "$return_ts" == "true" ]]; then
+    echo "$result" | jq -r '.ts' || echo "ERROR: failed to parse message ts from Slack response (exit $?)" >&2
+  fi
 }
 
 # Parse --var arguments and render template through jq
@@ -148,7 +150,7 @@ build_blocks() {
     unresolved=$(echo "$rendered" | jq -r '
       [.. | strings | [capture("\\{\\{(?<var>[^}]+)\\}\\}"; "g")] | .[].var]
       | unique | .[]
-    ' 2>/dev/null || true)
+    ' 2>/dev/null || echo "ERROR: failed to check unresolved template variables (exit $?)" >&2)
     if [[ -n "$unresolved" ]]; then
       echo "Error: template '$template_name' has unresolved variables: $(echo "$unresolved" | tr '\n' ', ' | sed 's/,$//')" >&2
       echo "Hint: pass --var <name>=<value> for each variable" >&2
@@ -236,17 +238,17 @@ case "$ACTION" in
       # Thread replies fetched for qualifying threads (reply_count>0), indented with ┗ prefix
       # Reactions from conversations.history natively — no extra API calls
       LAST_CHAT_TS="${LAST_CHAT_TS_ARG:-}"
-      MESSAGES_JSON=$(echo "$RAW" | jq -c '(.messages // []) | reverse | .[]' || true)
+      MESSAGES_JSON=$(echo "$RAW" | jq -c '(.messages // []) | reverse | .[]' || echo "ERROR: failed to parse Slack messages JSON (exit $?)" >&2)
       THREAD_COUNT=0
       while IFS= read -r MSG; do
         [[ -z "$MSG" ]] && continue
-        TS=$(echo "$MSG" | jq -r '.ts' || true)
-        USER=$(echo "$MSG" | jq -r '.user // "unknown"' || true)
-        TEXT=$(echo "$MSG" | jq -r '(.text // "") | gsub("\n"; " ") | gsub("\""; "\\\"")' || true)
-        REACTIONS=$(echo "$MSG" | jq -r 'if (.reactions // []) | length > 0 then " reactions=" + ([.reactions[].name] | join(",")) else "" end' || true)
+        TS=$(echo "$MSG" | jq -r '.ts' || echo "ERROR: failed to parse message ts (exit $?)" >&2)
+        USER=$(echo "$MSG" | jq -r '.user // "unknown"' || echo "ERROR: failed to parse message user (exit $?)" >&2)
+        TEXT=$(echo "$MSG" | jq -r '(.text // "") | gsub("\n"; " ") | gsub("\""; "\\\"")' || echo "ERROR: failed to parse message text (exit $?)" >&2)
+        REACTIONS=$(echo "$MSG" | jq -r 'if (.reactions // []) | length > 0 then " reactions=" + ([.reactions[].name] | join(",")) else "" end' || echo "ERROR: failed to parse message reactions (exit $?)" >&2)
         REPLY_COUNT=$(echo "$MSG" | jq -r '.reply_count // 0' || echo 0)
-        LATEST_REPLY=$(echo "$MSG" | jq -r '.latest_reply // ""' || true)
-        THREAD_TS_VAL=$(echo "$MSG" | jq -r 'if .thread_ts != null and .thread_ts != .ts then .thread_ts else "" end' || true)
+        LATEST_REPLY=$(echo "$MSG" | jq -r '.latest_reply // ""' || echo "ERROR: failed to parse latest_reply (exit $?)" >&2)
+        THREAD_TS_VAL=$(echo "$MSG" | jq -r 'if .thread_ts != null and .thread_ts != .ts then .thread_ts else "" end' || echo "ERROR: failed to parse thread_ts (exit $?)" >&2)
 
         LINE="ts=$TS user=$USER text=\"$TEXT\"$REACTIONS"
         [[ -n "$THREAD_TS_VAL" ]] && LINE="$LINE thread_ts=$THREAD_TS_VAL"
@@ -378,7 +380,7 @@ case "$ACTION" in
   download)
     [[ $# -lt 1 ]] && { echo "Usage: slack.sh download <url_private> [output_dir]" >&2; exit 1; }
     URL_PRIVATE="$1"; shift
-    OUTPUT_DIR="${1:-/tmp}"; shift 2>/dev/null || true
+    OUTPUT_DIR="${1:-/tmp}"; shift 2>/dev/null || true  # shift may fail if no output_dir arg; default already captured
     FILENAME=$(basename "$URL_PRIVATE" | cut -d'?' -f1)
     [[ -z "$FILENAME" ]] && FILENAME="slack-file-$(date +%s)"
     OUTPUT_PATH="$OUTPUT_DIR/$FILENAME"

--- a/plugins/kvido/skills/worker/task.sh
+++ b/plugins/kvido/skills/worker/task.sh
@@ -351,7 +351,7 @@ cmd_move() {
 
 cmd_list() {
   local status="${1:-}" sort_mode="" source_filter=""
-  shift || true
+  shift || true  # shift may fail if no args; handled by empty check below
 
   [[ -z "$status" ]] && { echo "Usage: task.sh list <status> [--sort priority] [--source SRC]" >&2; exit 1; }
 
@@ -490,7 +490,7 @@ cmd_migrate() {
 # --- Main ---
 
 COMMAND="${1:-}"
-shift || true
+shift || true  # shift may fail if no args; handled by case fallback below
 
 case "$COMMAND" in
   create)   cmd_create "$@" ;;


### PR DESCRIPTION
## Summary

- Replaces silent `|| true` error suppression with `echo "ERROR: ..." >&2` across 17 bash scripts
- Preserves `|| true` with explanatory comments where it is semantically correct (grep -c exit 1 on zero matches, shift on empty args)
- Refactors one `[[ cond ]] && cmd || true` into proper `if/fi` block in `slack_message()`
- All scripts pass `bash -n` syntax check

## Why

`|| true` was masking real failures (e.g. generate-dashboard.sh silently failing since PR #107). Now failures emit descriptive `ERROR:` lines to stderr, making them observable by the LLM agent for evaluation.

## Test plan

- [ ] Run `kvido dashboard` — verify dashboard generates without errors
- [ ] Run heartbeat cycle — verify no spurious ERROR lines in normal operation
- [ ] Verify `grep -c` patterns (Jira fetch with zero issues, empty WIP section) do NOT emit errors
- [ ] Check that actual failures (e.g. missing config) produce descriptive ERROR messages on stderr

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)