### PR TITLE
fix: trigger MCP fallback on network errors for Google sources in sandbox

### DIFF
--- a/plugins/kvido-calendar/skills/source-calendar/fetch.sh
+++ b/plugins/kvido-calendar/skills/source-calendar/fetch.sh
@@ -19,12 +19,19 @@ fi
 
 # Fetch events
 PARAMS=$(printf '{"calendarId":"primary","timeMin":"%s","timeMax":"%s","singleEvents":true,"orderBy":"startTime"}' "$TIME_MIN" "$TIME_MAX")
+GWS_ERR=$(mktemp)
 EVENTS=$(gws calendar events list \
   --params "$PARAMS" \
-  --format json 2>/dev/null) || {
-  echo "ERROR: calendar: gws calendar fetch failed for $TARGET_DATE" >&2
+  --format json 2>"$GWS_ERR") || {
+  ERR=$(cat "$GWS_ERR"); rm -f "$GWS_ERR"
+  if echo "$ERR" | grep -qiE 'no such host|connection refused|network is unreachable|dial tcp|EOF|timeout|i/o timeout'; then
+    echo "FALLBACK: gws network/auth error, use MCP" >&2
+    exit 10
+  fi
+  echo "ERROR: calendar: gws calendar fetch failed for $TARGET_DATE: $ERR" >&2
   exit 1
 }
+rm -f "$GWS_ERR"
 
 EVENT_COUNT=$(echo "$EVENTS" | jq -r '.items | length')
 

--- a/plugins/kvido-gmail/skills/source-gmail/fetch.sh
+++ b/plugins/kvido-gmail/skills/source-gmail/fetch.sh
@@ -22,13 +22,20 @@ if [[ "${1:-}" == "--watch" ]]; then
 fi
 
 # Fetch messages list
+GWS_ERR=$(mktemp)
 MESSAGES=$(gws gmail users messages list --params "$(jq -n \
   --arg q "$WATCH_QUERY" \
   --argjson max "$MAX_RESULTS" \
-  '{userId: "me", q: $q, maxResults: $max}')" 2>/dev/null) || {
-  echo "ERROR: gmail: gws gmail messages list failed" >&2
+  '{userId: "me", q: $q, maxResults: $max}')" 2>"$GWS_ERR") || {
+  ERR=$(cat "$GWS_ERR"); rm -f "$GWS_ERR"
+  if echo "$ERR" | grep -qiE 'no such host|connection refused|network is unreachable|dial tcp|EOF|timeout|i/o timeout'; then
+    echo "FALLBACK: gws network/auth error, use MCP" >&2
+    exit 10
+  fi
+  echo "ERROR: gmail: gws gmail messages list failed: $ERR" >&2
   exit 1
 }
+rm -f "$GWS_ERR"
 
 MSG_COUNT=$(echo "$MESSAGES" | jq -r '.messages | length')
 HAS_MORE=$(echo "$MESSAGES" | jq -r '.nextPageToken != null')

--- a/plugins/kvido/agents/gatherer.md
+++ b/plugins/kvido/agents/gatherer.md
@@ -1,7 +1,7 @@
 ---
 name: gatherer
 description: Discovers source plugins and fetches data, emitting change events to the event bus.
-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash, mcp__claude_ai_Google_Calendar__gcal_list_events, mcp__claude_ai_Gmail__gmail_search_messages, mcp__claude_ai_Gmail__gmail_read_message
 model: sonnet
 ---
 


### PR DESCRIPTION
Fixes #137

## Summary

- `kvido-calendar` and `kvido-gmail` fetch scripts now capture `gws` stderr and detect transport errors (DNS, connection refused, timeout, EOF) → exit code 10, triggering MCP fallback in the gatherer
- Auth errors (`401`/`403`) remain exit code 1 (hard error) — MCP would fail too in that case, so silently falling back would mask broken credentials
- `gatherer.md` tools list extended with `gcal_list_events`, `gmail_search_messages`, `gmail_read_message` so the agent can execute the MCP fallback path

## Test plan

- [ ] Simulate sandbox: rename `gws` binary, run `fetch.sh` → should return exit 10 + `FALLBACK:` message on stderr
- [ ] Simulate network error: run `fetch.sh` in environment with blocked DNS → exit 10
- [ ] Simulate auth error: run `fetch.sh` with invalid token → exit 1 (hard error, not fallback)
- [ ] Run `/kvido:heartbeat` in sandboxed environment → gatherer falls back to MCP and loads calendar/gmail data

🤖 Generated with [Claude Code](https://claude.com/claude-code)