### PR TITLE
fix: reduce heartbeat log limit to 5 on non-planner ticks

### DIFF
--- a/commands/heartbeat.md
+++ b/commands/heartbeat.md
@@ -47,7 +47,7 @@ The `user:` prefix means the message is from the workspace owner (you). The `bot
 
 The script automatically: increments iteration_count, sets last_heartbeat, reads Slack DM.
 
-Read current state via `kvido current get`. Review recent activity via `kvido log list --today --format human --limit 20`.
+Read current state via `kvido current get`. Review recent activity via `kvido log list --today --format human --limit 20` on planner ticks (`PLANNER_DUE=true`), or `--limit 5` on non-planner ticks.
 
 ### Recovery check
 


### PR DESCRIPTION
Closes #152

## Summary

- On planner ticks (`PLANNER_DUE=true`), the log review in Step 2 retains `--limit 20` for full context
- On non-planner ticks (`PLANNER_DUE=false`), the limit is reduced to `--limit 5`
- Reduces token consumption on the majority of heartbeat iterations (2 out of every 3 ticks by default with `planning_interval=3`)

## Test plan

- [ ] Run heartbeat on a non-planner tick, confirm log review uses `--limit 5`
- [ ] Run heartbeat on a planner tick (`PLANNER_DUE=true`), confirm log review uses `--limit 20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)