### PR TITLE
feat: reviewer agent for automated PR code review via codex

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -102,7 +102,31 @@ For markdown/agent definitions check:
 - Consistent formatting and structure
 - No hardcoded user-specific values (repo names, usernames) baked in — use template variables
 
-### Step 4: Update task and return output
+### Step 4: Post review comment on the PR/MR
+
+After composing the review body, post it as a comment so the author sees the findings directly in the PR/MR.
+
+Build the review body from the findings:
+- First line: `REVIEW PASSED` or `REVIEW FAILED`
+- Blocking issues (if any): numbered list with `[BUG]`, `[SECURITY]`, etc. labels
+- Advisory items (if any): brief bulleted list
+
+Post the comment:
+
+For GitHub:
+```bash
+gh pr review {{PR_NUMBER}} --repo {{REPO}} --comment --body "$REVIEW_BODY"
+```
+
+For GitLab:
+```bash
+glab mr note {{PR_NUMBER}} --repo {{REPO}} --message "$REVIEW_BODY" 2>/dev/null \
+  || glab mr note {{PR_NUMBER}} --message "$REVIEW_BODY"
+```
+
+If neither CLI is available (e.g. diff was fetched via `git diff` fallback), skip posting — the agent still returns full NL output for heartbeat delivery.
+
+### Step 5: Update task and return output
 
 Move the task to the appropriate status:
 


### PR DESCRIPTION
## Summary

- Reworks `agents/reviewer.md` — replaces codex-based implementation with direct LLM diff analysis
- Agent now fetches the PR/MR diff itself (via `gh pr diff` or `glab mr diff`) and performs the review without external tools
- Multi-platform support: GitHub (`gh`) and GitLab (`glab`) via `PLATFORM` template variable
- Users can extend with custom tools (codex, linters) via `kvido memory write reviewer` — not baked in
- Platform detection is fully generic: `github.com` → GitHub, `gitlab` → GitLab, no hardcoded domains
- `REPO`, `PLATFORM`, `PR_BRANCH` exposed as template variables for flexible dispatch

Closes #159.

## Test plan

- [ ] Dispatch reviewer agent with `PR_NUMBER=<n>` and `PLATFORM=github` — verify it fetches diff and returns `RESULT=PASS|FAIL`
- [ ] Dispatch with `PLATFORM=gitlab` and a GitLab MR number — verify `glab mr diff` is used
- [ ] Dispatch with empty `PLATFORM` and a `github.com` URL — verify auto-detection works
- [ ] Verify user customization via `kvido memory write reviewer` (e.g. add codex step) is applied
- [ ] On FAIL: verify task moves to `failed/` and planner can create follow-up
- [ ] On PASS: verify task moves to `done/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)