### PR TITLE
feat: planner model sizing (s→haiku, m→sonnet, l/xl→opus)

### DIFF
--- a/agents/planner.md
+++ b/agents/planner.md
@@ -62,7 +62,17 @@ Go through planner memory. For each rule:
 next_task=$(kvido task list todo --sort priority 2>/dev/null | head -1 || echo "")
 ```
 
-If non-empty, include worker dispatch for that task.
+If non-empty, include worker dispatch for that task. Read the task's `size` field via `kvido task read <slug>` and map it to a model hint:
+
+| size | model |
+|------|-------|
+| `s` | haiku |
+| `m` | sonnet |
+| `l` | opus |
+| `xl` | opus |
+| _(missing)_ | sonnet |
+
+Emit the dispatch as `DISPATCH worker <slug> model=<model>`.
 
 ## Step 4: Output
 
@@ -73,12 +83,12 @@ Print dispatch lines. Each dispatched agent is one line:
 ```
 DISPATCH gatherer
 DISPATCH triager
-DISPATCH worker deploy-hotfix
+DISPATCH worker deploy-hotfix model=sonnet
 DISPATCH librarian
 ```
 
 Rules:
-- One `DISPATCH <agent>` per line. Worker includes task slug: `DISPATCH worker <slug>`.
+- One `DISPATCH <agent>` per line. Worker includes task slug and model hint: `DISPATCH worker <slug> model=<model>`.
 - If nothing to dispatch: output `No dispatches needed.`
 - Ordering: by default heartbeat runs all in parallel. For sequential, use `DISPATCH_AFTER <agent> <after-agent>` (e.g., `DISPATCH_AFTER triager gatherer`).
 

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -12,6 +12,7 @@ You are the worker — you execute the assigned task autonomously and report the
 TASK_SLUG: {{TASK_SLUG}}
 INSTRUCTION: {{INSTRUCTION}}
 SIZE: {{SIZE}}
+MODEL: {{MODEL}}
 SOURCE_REF: {{SOURCE_REF}}
 
 ## Context

--- a/commands/heartbeat.md
+++ b/commands/heartbeat.md
@@ -135,14 +135,14 @@ The planner output uses structured lines:
 ```
 DISPATCH gatherer
 DISPATCH triager
-DISPATCH worker deploy-hotfix
+DISPATCH worker deploy-hotfix model=sonnet
 DISPATCH librarian
 DISPATCH_AFTER triager gatherer
 NOTIFY stale-worker fix-auth-bug
 ```
 
 - `DISPATCH <agent>` — dispatch agent (parallel by default)
-- `DISPATCH worker <slug>` — dispatch worker for specific task
+- `DISPATCH worker <slug> [model=<model>]` — dispatch worker for specific task; optional `model=` token selects model (haiku/sonnet/opus, default sonnet)
 - `DISPATCH_AFTER <agent> <after-agent>` — sequential ordering
 - `NOTIFY <type> [detail]` — heartbeat handles notification directly
 - `No dispatches needed.` — skip Steps 5 and 6
@@ -164,7 +164,7 @@ For each `DISPATCH` line, dispatch the agent with `run_in_background: true`:
 3. Dispatch agent (`run_in_background: true`)
 4. Log: `kvido log add heartbeat dispatch --message "<agent>"`
 
-**Worker specifics:** `DISPATCH worker <slug>` — read task first (`kvido task read "$slug"`), if SOURCE_REF is set send ack via `kvido slack reply`, then `kvido task move "$slug" in-progress`.
+**Worker specifics:** `DISPATCH worker <slug> [model=<model>]` — parse the optional `model=` token from the DISPATCH line (default: `sonnet` if absent). Read task first (`kvido task read "$slug"`), if SOURCE_REF is set send ack via `kvido slack reply`, then `kvido task move "$slug" in-progress`. Pass the resolved model name as the `model` parameter to the Agent tool when dispatching the worker.
 
 **Maintenance specifics:** If another `maintenance:*` task is pending/in_progress, set `addBlockedBy`.
 


### PR DESCRIPTION
## Summary

- **planner.md**: reads `size` field from next task, maps it to model hint (s→haiku, m→sonnet, l/xl→opus, missing→sonnet), emits `DISPATCH worker <slug> model=<model>`
- **heartbeat.md**: parses optional `model=` token from DISPATCH worker lines, defaults to sonnet, passes resolved model name to Agent tool
- **worker.md**: adds `MODEL: {{MODEL}}` field to Assignment block for observability/tracing

## Test plan
- [ ] Verify planner emits `DISPATCH worker <slug> model=haiku` for size=s tasks
- [ ] Verify planner emits `DISPATCH worker <slug> model=opus` for size=l and size=xl tasks
- [ ] Verify heartbeat passes the model to Agent tool when dispatching worker
- [ ] Verify heartbeat defaults to sonnet when model= is absent from DISPATCH line

Closes #154

Generated with [Claude Code](https://claude.ai/claude-code)