### PR TITLE
feat: librarian reads current state for better extraction

### DIFF
--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -17,7 +17,8 @@ Gather today's signal and persist what's worth remembering.
 Sources (in rough priority order):
 1. **Journal file** (path in prompt) — the user's narrative of the day
 2. **Activity log** (`kvido log list --today --format json`) — machine record of what happened
-3. **Existing memory files** — skim for facts that need updating based on today's signal
+3. **Current state** (`kvido current get`) — WIP items, active focus, and pinned items; use as supplementary context to spot what's actively in flight and may not be fully captured in the log
+4. **Existing memory files** — skim for facts that need updating based on today's signal
 
 For each thing worth persisting, write or update the appropriate file via `kvido memory`:
 - Project states → `kvido memory read projects/<project>` / `kvido memory write projects/<project>` (update History + Current state; create if new)


### PR DESCRIPTION
## Summary

- Librarian now reads `kvido current get` as part of extraction phase
- Surfaces WIP items, active focus, and pinned items as supplementary context
- Helps extraction decisions by providing data not fully captured in activity log

## Test plan

- [ ] Run librarian agent — verify it reads current state alongside log

🤖 Generated with [Claude Code](https://claude.com/claude-code)