### PR TITLE
fix: release blockers — scout parsing, task list status arg, reviewer cleanup

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -143,7 +143,7 @@ kvido task move {{TASK_SLUG}} failed
 Log the result:
 
 ```bash
-kvido log add reviewer complete --message "PR #{{PR_NUMBER}}: RESULT=PASS|FAIL" --task_id "{{TASK_SLUG}}"
+kvido log add reviewer complete --message "PR #{{PR_NUMBER}}: RESULT=$RESULT" --task_id "{{TASK_SLUG}}"
 ```
 
 ## Output Format
@@ -158,7 +158,7 @@ Findings: 2 suggestions (non-blocking): 1) Missing inline comment on complex reg
 No security or logic issues found.
 
 RESULT=PASS
-PR: https://github.com/spajxo/kvido/pull/42
+PR: https://github.com/org/repo/pull/42
 Task: {{TASK_SLUG}}
 Type: reviewer-report
 ```
@@ -172,7 +172,7 @@ Blocking issues found:
 2) [SECURITY] Missing input validation before passing user input to eval
 
 RESULT=FAIL
-PR: https://github.com/spajxo/kvido/pull/42
+PR: https://github.com/org/repo/pull/42
 Task: {{TASK_SLUG}}
 Type: reviewer-error
 ```
@@ -181,7 +181,7 @@ Type: reviewer-error
 
 Users can extend the reviewer via `kvido memory write reviewer`. Common customizations:
 
-```markdown
+~~~markdown
 ## Custom review tools
 Run codex review before LLM analysis:
 ```bash
@@ -192,7 +192,7 @@ If codex exits non-zero, treat as FAIL and include its output in findings.
 ## Extra rules
 - Enforce conventional commits in PR title
 - Require changelog entry for breaking changes
-```
+~~~
 
 This allows tool-specific workflows (codex, custom linters, security scanners) without baking them into the agent definition.
 

--- a/agents/sources/gitlab.md
+++ b/agents/sources/gitlab.md
@@ -43,8 +43,8 @@ Repos with `type: knowledge-base` are always skipped (no MRs).
 - `mr:<repo>!<iid>:comment_<count>` — MR comment count change
 
 #### Triage Detection
-New MR where I am reviewer, no matching task found via `kvido task list --source gitlab` → triage item.
-Dedup: check existing tasks with `kvido task list --source gitlab --source-ref <repo>!<IID>`.
+New MR where I am reviewer, no matching task found via `kvido task list triage --source gitlab` → triage item.
+Dedup: check existing tasks with `kvido task list triage --source gitlab --source-ref <repo>!<IID>`.
 Repos with type: knowledge-base → skip triage detection.
 
 #### Notification Rules

--- a/agents/sources/jira.md
+++ b/agents/sources/jira.md
@@ -20,7 +20,7 @@ Output: plain text, one block per project.
 
 **triage-detect:** After fetch — new ticket assignee=me → dedup check:
 ```bash
-kvido task list --source jira --format slug-title
+kvido task list triage --source jira --format slug-title
 ```
 If no matching task → create triage task:
 ```bash

--- a/commands/heartbeat.md
+++ b/commands/heartbeat.md
@@ -254,6 +254,7 @@ Chat-agent uses ack reactions only (see above), not status edits.
 | gatherer | `event` | per urgency rules | Parse findings, each as separate notification |
 | triager | `triage-item` | `immediate` | For triage items needing user attention, save returned `ts` to task frontmatter: `kvido task update <id> triage_slack_ts <ts>` |
 | maintenance | agent name as template, fallback `event` | per delivery rules | When falling back to `event`, set `--var severity_bar=:large_yellow_circle:` as default |
+| scout | `event` | per scout's suggested urgency in each finding block | Split output by `SCOUT FINDING:` markers — deliver each finding as a separate notification |
 
 ### Digest threading
 


### PR DESCRIPTION
## Summary

Pre-release fixes for v0.28.0:

**Blocking:**
- heartbeat.md: Added scout-specific row to per-agent delivery table — splits `SCOUT FINDING:` blocks into separate notifications
- agents/sources/jira.md: Fixed `kvido task list --source jira` → `kvido task list triage --source jira`
- agents/sources/gitlab.md: Fixed both `kvido task list --source gitlab` calls with status arg

**Advisory:**
- agents/reviewer.md: Replaced hardcoded `spajxo/kvido` URL with `org/repo` placeholder
- agents/reviewer.md: Fixed nested markdown fences (~~~markdown)
- agents/reviewer.md: Fixed log message `RESULT=PASS|FAIL` → dynamic `RESULT=$RESULT`

## Test plan

- [ ] Verify heartbeat splits scout findings into separate notifications
- [ ] Verify `kvido task list triage --source jira` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)