### PR TITLE
refactor: restructure KVIDO_HOME — instructions/, tasks/, unstructured memory/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ scripts/
 ├── current/                       ← current focus management
 ├── log/                           ← activity logging
 ├── memory/                        ← memory file access
+├── instructions/                  ← per-agent instruction file access
 └── migrate/                       ← state migration
 kvido                              ← CLI entry point
 settings.json.example              ← config reference template
@@ -51,17 +52,19 @@ settings.json.example              ← config reference template
 - **Planner is a pure scheduler** — returns NL dispatch instructions, does not execute anything.
 - **Prompts default to English**. Runtime language is configured in the user's `memory/persona.md`.
 - **Exit code 10** in fetch scripts means "CLI tool not available, use MCP fallback". The gatherer agent documents MCP fallback procedures for each source.
-- **Memory files** are accessed via `kvido memory read <name>` / `kvido memory write <name>` / `kvido memory tree` — never via hardcoded paths.
+- **Memory files** are accessed via `kvido memory read <name>` / `kvido memory write <name>` / `kvido memory tree` — never via hardcoded paths. Memory is unstructured — librarian manages organization autonomously.
+- **Per-agent instructions** are accessed via `kvido instructions read <agent-name>` / `kvido instructions write <agent-name>` — stored in `$KVIDO_HOME/instructions/`.
 - **Agent instructions** are self-contained in `agents/*.md` files. The gatherer agent contains all source fetch instructions inline.
-- **Agents read user customizations** via `kvido memory read <agent-name>` — users can add per-agent instructions in `$KVIDO_HOME/memory/`.
 - **Sources are toggled** via `sources.<name>.enabled` in `settings.json` (default: `true`). No separate plugin installation needed.
 - **Agent output contract** is formally defined in `docs/agent-output-contract.md` — specifies what heartbeat expects from each agent's stdout output.
 
 ## KVIDO_HOME
 
 All runtime files live in `$KVIDO_HOME` (default: `~/.config/kvido`):
-- `state/` — ephemeral runtime (current.md, session-context.md, log.jsonl, state.json, tasks/, dashboard.html)
-- `memory/` — persistent (memory.md, journals, projects, weekly, learnings)
+- `state/` — ephemeral runtime (current.md, session-context.md, log.jsonl, state.json, dashboard.html)
+- `tasks/` — task queue (`<status>/<id>-<slug>.md` files, task_counter)
+- `instructions/` — per-agent instruction files (read via `kvido instructions read <agent>`)
+- `memory/` — persistent, unstructured (memory.md, journals, projects, weekly, learnings) — librarian manages organization
 - `settings.json` — configuration (JSON, parsed via `scripts/config.sh`)
 - `.env` — secrets (Slack tokens, channel IDs)
 
@@ -116,7 +119,7 @@ Sources are configured in `settings.json` under `sources.*`. Each source can be 
 
 ## Task system
 
-Tasks live in `$KVIDO_HOME/state/tasks/<status>/` as markdown files with YAML frontmatter. Canonical statuses (defined in `scripts/worker/task.sh`):
+Tasks live in `$KVIDO_HOME/tasks/<status>/` as markdown files with YAML frontmatter. Canonical statuses (defined in `scripts/worker/task.sh`):
 
 ```
 triage → todo → in-progress → done
@@ -130,7 +133,7 @@ CLI: `kvido task <create|read|move|list|count|find|note> [args]` (delegates to `
 
 Entry point: `./kvido` (symlinked to `~/.local/bin/kvido` via `kvido --install`). Resolves plugin root from `CLAUDE_PLUGIN_ROOT` → script directory → plugin registry fallback.
 
-Key commands: `kvido heartbeat`, `kvido task ...`, `kvido state ...`, `kvido config ...`, `kvido slack ...`, `kvido log ...`, `kvido memory ...`, `kvido dashboard`. Run `kvido --help` for full reference.
+Key commands: `kvido heartbeat`, `kvido task ...`, `kvido state ...`, `kvido config ...`, `kvido slack ...`, `kvido log ...`, `kvido memory ...`, `kvido instructions ...`, `kvido dashboard`. Run `kvido --help` for full reference.
 
 ## Working on this codebase
 

--- a/agents/chat-agent.md
+++ b/agents/chat-agent.md
@@ -123,5 +123,5 @@ If anything fails:
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read chat-agent 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read chat-agent 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/agents/gatherer.md
+++ b/agents/gatherer.md
@@ -139,5 +139,5 @@ Always include the full clickable URL for every finding.
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read gatherer 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read gatherer 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -80,5 +80,5 @@ Always read files before editing. Log what you did (return summary).
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read librarian 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read librarian 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -17,7 +17,7 @@ You are the planner — a pure scheduler. You decide what should happen, not how
    kvido current get
    ```
 
-3. Read scheduling rules: `kvido memory read planner` — this is your primary instruction set. If missing, output `No planner memory found.` and stop.
+3. Read scheduling rules: `kvido instructions read planner` — this is your primary instruction set. If missing, output `No planner instructions found.` and stop.
 
 ### Maintenance Agents
 
@@ -152,10 +152,10 @@ Rules:
 - **State-first.** Check `kvido state` before dispatching to avoid duplicates.
 - **Idempotent.** If already dispatched today, skip.
 - **Triage is triager's job.** Do not triage tasks — only dispatch the triager agent.
-- **Planner memory is the source of truth.** All scheduling rules come from `kvido memory read planner`. Do not invent rules.
+- **Planner instructions are the source of truth.** All scheduling rules come from `kvido instructions read planner`. Do not invent rules.
 - **Full snapshot before decisions.** Always read triage + todo + in-progress before deciding what to dispatch.
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read planner 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read planner 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/agents/project-enricher.md
+++ b/agents/project-enricher.md
@@ -25,5 +25,5 @@ Return: "Enriched: <project> — <what changed>" or "Enriched: <project> — no 
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read project-enricher 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read project-enricher 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -22,7 +22,7 @@ TASK_SLUG: {{TASK_SLUG}}
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read reviewer 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read reviewer 2>/dev/null || true`
 Apply any additional rules or overrides. Users may configure custom review tools (e.g. codex, custom linters) via this memory file.
 
 ## Process

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -79,5 +79,5 @@ Heartbeat will deliver each SCOUT FINDING block as a separate Slack notification
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read scout 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read scout 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/agents/self-improver.md
+++ b/agents/self-improver.md
@@ -294,5 +294,5 @@ For plugin issues include the issue URL. For gh fallback include: `"Plugin propo
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read self-improver 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read self-improver 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/agents/triager.md
+++ b/agents/triager.md
@@ -138,5 +138,5 @@ Triager: no triage items pending
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read triager 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read triager 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -214,5 +214,5 @@ Report appearance:
 
 ## User Instructions
 
-Read user-specific instructions: `kvido memory read worker 2>/dev/null || true`
+Read user-specific instructions: `kvido instructions read worker 2>/dev/null || true`
 Apply any additional rules or overrides.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -132,7 +132,8 @@ Create missing directories:
 
 ```bash
 mkdir -p $KVIDO_HOME/memory/{journal,weekly,projects,people,decisions,archive/{journal,weekly,decisions}}
-mkdir -p $KVIDO_HOME/state/tasks/{triage,todo,in-progress,done,failed,cancelled}
+mkdir -p $KVIDO_HOME/instructions
+mkdir -p $KVIDO_HOME/tasks/{triage,todo,in-progress,done,failed,cancelled}
 ```
 
 For each missing file, create with minimal content:

--- a/hooks/build-context.sh
+++ b/hooks/build-context.sh
@@ -35,10 +35,10 @@ fi
 ITER=$(kvido state get heartbeat.iteration_count 2>/dev/null || echo 0)
 echo "- Heartbeat iteration: $ITER"
 
-if [[ -d "$KVIDO_HOME/state/tasks" ]]; then
-  TODO=$(find "$KVIDO_HOME/state/tasks/todo/" -name "*.md" 2>/dev/null | wc -l || echo 0)
-  WIP_T=$(find "$KVIDO_HOME/state/tasks/in-progress/" -name "*.md" 2>/dev/null | wc -l || echo 0)
-  TRIAGE=$(find "$KVIDO_HOME/state/tasks/triage/" -name "*.md" 2>/dev/null | wc -l || echo 0)
+if [[ -d "$KVIDO_HOME/tasks" ]]; then
+  TODO=$(find "$KVIDO_HOME/tasks/todo/" -name "*.md" 2>/dev/null | wc -l || echo 0)
+  WIP_T=$(find "$KVIDO_HOME/tasks/in-progress/" -name "*.md" 2>/dev/null | wc -l || echo 0)
+  TRIAGE=$(find "$KVIDO_HOME/tasks/triage/" -name "*.md" 2>/dev/null | wc -l || echo 0)
   echo "- Tasks: ${TODO} todo, ${WIP_T} in-progress, ${TRIAGE} triage"
 fi
 

--- a/kvido
+++ b/kvido
@@ -174,7 +174,8 @@ Commands:
   log <subcommand> [args]           Activity log (add, list, purge)
   slack <subcommand> [args]         Slack messaging (send, reply, edit, read, react, delete, upload...)
   dashboard                         Open the dashboard HTML in the default browser
-  memory <subcommand>               Memory access (read, write, tree)
+  memory <subcommand>               Memory access (read, write, tree, search, list)
+  instructions <subcommand>         Per-agent instructions (read, write, list, tree)
   current <get|dump|summary|set|append|clear>  Read/write current focus sections (state/current.md)
   migrate                           Run lazy state migration (heartbeat-state/planner-state → state)
   scripts/<script>.sh [args]        Direct script dispatch (backward compat)

--- a/scripts/heartbeat/generate-dashboard.sh
+++ b/scripts/heartbeat/generate-dashboard.sh
@@ -6,8 +6,8 @@
 #   1. kvido log list (unified activity log)
 #   2. kvido state (heartbeat.* keys)
 #   3. state/current.md
-#   4. state/tasks/ (local task files)
-#   5. state/tasks/*/*.md (full task data for task list/detail view)
+#   4. tasks/ (local task files)
+#   5. tasks/*/*.md (full task data for task list/detail view)
 
 set -euo pipefail
 
@@ -176,7 +176,7 @@ fi
 # ---------------------------------------------------------------------------
 # Source 6: Full task data for task list/detail views
 # ---------------------------------------------------------------------------
-TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DIR="$KVIDO_HOME/tasks"
 TASKS_JSON="[]"
 
 _read_fm() {

--- a/scripts/instructions/instructions.sh
+++ b/scripts/instructions/instructions.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# instructions.sh — Per-agent instruction file access
+# Storage: $KVIDO_HOME/instructions/ (markdown files)
+#
+# Usage:
+#   instructions.sh read <name>            → cat file to stdout (exit 1 if missing)
+#   instructions.sh write <name>           → stdin → file (creates parent dirs)
+#   instructions.sh list                   → list instruction files
+#   instructions.sh tree                   → tree structure with absolute root path
+
+set -euo pipefail
+
+KVIDO_HOME="${KVIDO_HOME:-$HOME/.config/kvido}"
+INSTRUCTIONS_DIR="${KVIDO_HOME}/instructions"
+
+# Resolve name → absolute path (auto-append .md if no extension)
+# Rejects path traversal (.. components, absolute paths)
+_resolve() {
+  local name="$1"
+  if [[ "$name" == /* || "$name" == *..* ]]; then
+    echo "ERROR: invalid instruction name (path traversal): $name" >&2
+    exit 1
+  fi
+  if [[ "$name" != *.* ]]; then
+    name="${name}.md"
+  fi
+  echo "${INSTRUCTIONS_DIR}/${name}"
+}
+
+case "${1:-}" in
+  --help|-h)
+    cat <<'HELP'
+kvido instructions — per-agent instruction file access
+
+Usage: kvido instructions <subcommand> [args]
+
+Subcommands:
+  read <name>              Print instruction file to stdout (exit 1 if missing)
+  write <name>             Write stdin to instruction file (creates parent dirs)
+  list                     List instruction files
+  tree                     Show instruction directory structure
+
+File names resolve to $KVIDO_HOME/instructions/<name>.md (auto-appends .md).
+Path traversal (.. or absolute paths) is rejected.
+
+Per-agent instructions are read by agents at startup. Users can customize
+agent behavior by writing instruction files named after the agent
+(e.g. `kvido instructions write worker`).
+
+Examples:
+  kvido instructions read worker
+  echo "Always use conventional commits" | kvido instructions write worker
+  kvido instructions list
+  kvido instructions tree
+HELP
+    exit 0
+    ;;
+  read)
+    [[ -z "${2:-}" ]] && { echo "Usage: instructions.sh read <name>" >&2; exit 1; }
+    FILE="$(_resolve "$2")"
+    if [[ ! -f "$FILE" ]]; then
+      echo "ERROR: instruction file not found: $FILE" >&2
+      exit 1
+    fi
+    cat "$FILE"
+    ;;
+  write)
+    [[ -z "${2:-}" ]] && { echo "Usage: instructions.sh write <name>" >&2; exit 1; }
+    FILE="$(_resolve "$2")"
+    mkdir -p "$(dirname "$FILE")"
+    cat > "$FILE"
+    ;;
+  list)
+    if [[ ! -d "$INSTRUCTIONS_DIR" ]]; then
+      echo "ERROR: instructions directory not found: $INSTRUCTIONS_DIR" >&2
+      exit 1
+    fi
+    find "$INSTRUCTIONS_DIR" -name "*.md" | sort | while IFS= read -r filepath; do
+      echo "${filepath#"${INSTRUCTIONS_DIR}/"}"
+    done
+    ;;
+  tree)
+    if [[ ! -d "$INSTRUCTIONS_DIR" ]]; then
+      echo "ERROR: instructions directory not found: $INSTRUCTIONS_DIR" >&2
+      exit 1
+    fi
+    if command -v tree &>/dev/null; then
+      tree -F --noreport "$INSTRUCTIONS_DIR"
+    else
+      echo "${INSTRUCTIONS_DIR}/"
+      (cd "$INSTRUCTIONS_DIR" && find . -not -name '.' | sort | while IFS= read -r path; do
+        path="${path#./}"
+        depth=$(echo "$path" | tr -cd '/' | wc -c)
+        indent=""
+        for ((i=0; i<depth; i++)); do indent+="    "; done
+        name=$(basename "$path")
+        if [[ -d "$INSTRUCTIONS_DIR/$path" ]]; then
+          echo "${indent}${name}/"
+        else
+          echo "${indent}${name}"
+        fi
+      done)
+    fi
+    ;;
+  *)
+    cat >&2 <<USAGE
+Usage: instructions.sh <command> [args]
+
+Commands:
+  read <name>              Read instruction file to stdout
+  write <name>             Write stdin to instruction file
+  list                     List instruction files
+  tree                     Show instruction directory structure
+
+Run 'kvido instructions --help' for details.
+USAGE
+    exit 1
+    ;;
+esac

--- a/scripts/migrate/migrate.sh
+++ b/scripts/migrate/migrate.sh
@@ -7,6 +7,8 @@
 #   state/heartbeat-state.json → state/state.json (heartbeat.* keys)
 #   state/planner-state.json → state/state.json (planner.* keys)
 #   state/source-health.json → state/state.json (source-health.* keys)
+#   state/tasks/ → tasks/ (v0.29.0)
+#   state/task_counter → tasks/task_counter (v0.29.0)
 
 set -euo pipefail
 
@@ -93,6 +95,25 @@ if [[ -f "$OLD_SOURCE_HEALTH" ]]; then
   rm "$OLD_SOURCE_HEALTH"
   rm -f "${OLD_SOURCE_HEALTH}.lock"
   migrated=1
+fi
+
+# Migrate state/tasks/ → tasks/ (v0.29.0)
+OLD_TASKS_DIR="${KVIDO_HOME}/state/tasks"
+NEW_TASKS_DIR="${KVIDO_HOME}/tasks"
+if [[ -d "$OLD_TASKS_DIR" && ! -d "$NEW_TASKS_DIR" ]]; then
+  mv "$OLD_TASKS_DIR" "$NEW_TASKS_DIR"
+  migrated=1
+  echo "migrate: moved state/tasks/ → tasks/" >&2
+fi
+
+# Migrate state/task_counter → tasks/task_counter (v0.29.0)
+OLD_COUNTER="${KVIDO_HOME}/state/task_counter"
+NEW_COUNTER="${KVIDO_HOME}/tasks/task_counter"
+if [[ -f "$OLD_COUNTER" && ! -f "$NEW_COUNTER" ]]; then
+  mkdir -p "$NEW_TASKS_DIR"
+  mv "$OLD_COUNTER" "$NEW_COUNTER"
+  migrated=1
+  echo "migrate: moved state/task_counter → tasks/task_counter" >&2
 fi
 
 if [[ "$migrated" -eq 1 ]]; then

--- a/scripts/worker/task.sh
+++ b/scripts/worker/task.sh
@@ -21,7 +21,7 @@
 set -euo pipefail
 
 KVIDO_HOME="${KVIDO_HOME:-$HOME/.config/kvido}"
-TASKS_DIR="${TASKS_DIR:-${KVIDO_HOME}/state/tasks}"
+TASKS_DIR="${TASKS_DIR:-${KVIDO_HOME}/tasks}"
 STATUSES="triage todo in-progress done failed cancelled"
 
 # shellcheck source=../lib.sh
@@ -126,7 +126,7 @@ _now() {
 }
 
 _next_id() {
-  local counter_file="$KVIDO_HOME/state/task_counter"
+  local counter_file="$KVIDO_HOME/tasks/task_counter"
   local id=0
   [[ -f "$counter_file" ]] && id=$(cat "$counter_file")
   id=$((id + 1))
@@ -504,7 +504,7 @@ cmd_count() {
 }
 
 cmd_migrate() {
-  local counter_file="$KVIDO_HOME/state/task_counter"
+  local counter_file="$KVIDO_HOME/tasks/task_counter"
   local all_tasks=()
 
   # Collect all tasks without numeric prefix


### PR DESCRIPTION
## Summary
- New `kvido instructions read/write/list/tree` command for per-agent instruction files
- `state/tasks/` moved to top-level `tasks/` (including task_counter)
- All 10 agent files updated: `kvido memory read <agent>` → `kvido instructions read <agent>`
- Auto-migration in `migrate.sh` for existing installations
- CLAUDE.md updated with new layout documentation

Closes #84 task

## Test plan
- [ ] Verify `kvido instructions read planner` works
- [ ] Verify `kvido task list todo` still works with new tasks/ path
- [ ] Run `/kvido:setup` health check
- [ ] Confirm migration moves existing state/tasks/ on first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>