### PR TITLE
refactor: less prescriptive agent output, delegate tone to persona.md

### DIFF
--- a/agents/chat-agent.md
+++ b/agents/chat-agent.md
@@ -100,11 +100,17 @@ For queries requiring lookup (Jira status, MR info, calendar, Slack search) — 
 
 Don't send messages directly. Return NL output for heartbeat delivery.
 
-Always include:
-- **Reply:** Response text for the user
-- **Thread:** thread_ts if replying to a thread, empty if flat
-- **Type:** chat-reply
+Write your reply as natural text in the tone from `persona.md`. Heartbeat needs these routing fields:
 
+```
+Reply: <response text>
+Thread: <thread_ts or empty>
+Type: chat-reply
+```
+
+- `Reply:` — the message text; write conversationally per persona tone
+- `Thread:` — parent `thread_ts` if replying in a thread; empty for flat messages
+- `Type:` — always `chat-reply`
 ## Rules
 
 - Reply concisely. No filler.

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -159,41 +159,19 @@ If this check fails: do NOT push. Report failure — the worktree was created fr
 
 Don't send messages via `kvido slack`. Return natural language result of the work.
 
-Always include:
-- **Result:** summary of what was done
-- **Task:** #{{TASK_ID}} — {{TITLE}}
-- **Type:** worker-report (or worker-error on failure)
-- **Source:** {{SOURCE_REF}} (if non-empty — for thread context)
+Write a free-form message in the tone and language from `persona.md` (Heartbeat section). Be specific and concrete — not "checked MRs" but "group/project !342: waiting 3 days, assignee Jan, 2 unresolved comments". If output > 3000 chars, trim to top 5 items + "and X more".
 
-Success example:
+Heartbeat needs these routing fields at the end of your output:
+
 ```
-Task #47 "Security review ds-parking" done. Found 2 medium issues.
-Result: 1) SQL injection at endpoint /api/search 2) Missing rate limiting at /api/upload
-Task: #47 — Security review ds-parking
+Task: #{{TASK_ID}}
 Type: worker-report
-Source: 1773933088.437
+Source: {{SOURCE_REF}}
 ```
 
-Failure example:
-```
-Task #23 "Sync Jira epics" failed. Reason: API timeout after 3 attempts.
-Task: #23 — Sync Jira epics
-Type: worker-error
-```
-
-Report appearance:
-```
-🔧 *<brief task name>*
-━━━━━━━━━━━━━━━━
-✅ <concrete result 1>
-✅ <concrete result 2>
-⚠️ <warning — only if relevant>
-
-#<id> · <Xm Ys>
-```
-
-**Specificity is mandatory.** Not "checked MRs" but "group/project !342: waiting 3 days, assignee Jan, 2 unresolved comments". If output > 3000 chars → trim to top 5 items + "and X more".
-
+- `Task:` — always include (numeric ID for routing)
+- `Type:` — always `worker-report`; heartbeat detects success vs. failure from context
+- `Source:` — include only if `{{SOURCE_REF}}` is non-empty (used for Slack thread routing)
 ## Error handling
 1. `kvido task note {{TASK_ID}} "## Failed\n<reason>"`
 2. `kvido task move {{TASK_ID}} failed`

--- a/commands/heartbeat.md
+++ b/commands/heartbeat.md
@@ -250,7 +250,7 @@ Chat-agent uses ack reactions only (see above), not status edits.
 | Agent | Template | Level | Notes |
 |-------|----------|-------|-------|
 | chat-agent | `chat` | always immediate | Extract `ORIGINAL_TS` from task subject `chat:<ts>`. If agent returns `Thread` non-empty: `kvido slack reply dm <Thread> chat --var message="<Reply>"`. If `Thread` empty: `kvido slack reply dm <ORIGINAL_TS> chat --var message="<Reply>"`. After delivery, check for `pending` chat tasks → dispatch next (FIFO) |
-| worker | `worker-report` | `high` for error, else `normal` | — |
+| worker | `worker-report` | `high` for error, else `normal` | Pass worker output (up to routing fields) as `--var message="..."`. If `Source:` is a Slack `ts`, reply in that thread. |
 | gatherer | `event` | per urgency rules | Parse findings, each as separate notification |
 | triager | `triage-item` | `immediate` | For triage items needing user attention, save returned `ts` to task frontmatter: `kvido task update <id> triage_slack_ts <ts>` |
 | maintenance | agent name as template, fallback `event` | per delivery rules | When falling back to `event`, set `--var severity_bar=:large_yellow_circle:` as default |

--- a/docs/agent-output-contract.md
+++ b/docs/agent-output-contract.md
@@ -144,49 +144,33 @@ Triager: no triage items pending
 
 **Purpose:** Reports the result of executing a task.
 
-**Format (success):**
+**Format:**
+
+The worker writes a free-form natural language message in the tone from `persona.md` (Heartbeat section), followed by routing fields:
 
 ```
-Task <slug> done. <brief summary>.
-Result: <concrete result 1>; <concrete result 2>
-Task: <slug>
+<free-form result message>
+
+Task: #<task_id>
 Type: worker-report
 Source: <source_ref>
 ```
 
-**Format (failure):**
+The free-form message contains the substance — what was done, findings, branch name, etc. Tone and structure are controlled by persona, not by this contract.
 
-```
-Task <slug> failed. Reason: <reason>.
-Task: <slug>
-Type: worker-report
-```
-
-**Parsed fields:**
+**Routing fields:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `Task:` | yes | Task slug — used for routing and logging |
-| `Type:` | yes | Always `worker-report` — error vs. success is determined by template variables (e.g. presence of `Result:` field), not a separate template |
+| `Task:` | yes | Numeric task ID — used for routing and logging |
+| `Type:` | yes | Always `worker-report` |
 | `Source:` | if non-empty | Original source ref (Slack `ts`, Jira key, etc.) — used for thread routing |
-| `Result:` | for success | Summary of what was done — absent on failure |
 
-**Delivery:** Heartbeat always uses `worker-report` template. Level is `normal` on success, `high` on failure (detected by absence of `Result:`). If `Source:` contains a Slack `ts`, heartbeat replies in that thread.
+**Delivery:** Heartbeat uses `worker-report` template with `--var message="<full output above routing fields>"`. Level is `normal` on success, `high` on failure (detected by context — e.g. "failed" or absence of substantive result). If `Source:` contains a Slack `ts`, heartbeat replies in that thread.
 
-**Slack appearance** (what heartbeat renders):
-
-```
-🔧 *<brief task name>*
-━━━━━━━━━━━━━━━━
-✅ <concrete result 1>
-✅ <concrete result 2>
-⚠️ <warning — only if relevant>
-
-<slug> · <Xm Ys>
-```
+**Slack appearance** (what heartbeat renders): the free-form message as-is in mrkdwn, plus context footer with task ID and duration.
 
 **Fallback:** If `Type:` field is missing, heartbeat treats the output as `worker-report` and delivers as-is with `normal` level.
-
 ---
 
 ### 2.4 Chat-agent
@@ -196,16 +180,18 @@ Type: worker-report
 **Format:**
 
 ```
-Reply: <response text for the user>
+Reply: <response text>
 Thread: <thread_ts or empty>
 Type: chat-reply
 ```
+
+The `Reply:` value is free-form text written in the tone from `persona.md`. Heartbeat delivers it as-is.
 
 **Parsed fields:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `Reply:` | yes | The response text to deliver to the user |
+| `Reply:` | yes | The response text — free-form, per persona tone |
 | `Thread:` | yes | If replying to a thread: the parent message `thread_ts`. If flat message: empty string. **Never `ts` of the message itself.** |
 | `Type:` | yes | Always `chat-reply` |
 

--- a/scripts/slack/templates/worker-report.json
+++ b/scripts/slack/templates/worker-report.json
@@ -1,5 +1,5 @@
 [
-  {"type":"section","text":{"type":"mrkdwn","text":":gear: *{{title}}*\n{{results}}"}},
+  {"type":"section","text":{"type":"mrkdwn","text":"{{message}}"}},
   {"type":"context","elements":[
     {"type":"mrkdwn","text":"#{{task_id}} · {{duration}}"}
   ]}


### PR DESCRIPTION
## Summary
- Worker output: removed rigid `Result:/Task:/Type:` template, now free-form NL with routing fields only
- Chat-agent: `Reply:` content is free-form per persona tone
- `worker-report.json` template: single `{{message}}` field replaces dual title+results
- Agent output contract and heartbeat delivery updated

5 files changed. Closes #88 task.

## Test plan
- [ ] Verify worker output is parsed correctly by heartbeat
- [ ] Check worker-report.json renders single message field in Slack
- [ ] Confirm chat-agent replies maintain routing fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>