### PR TITLE
feat: route kvido memory-sync to KVIDO_HOME/scripts/

### DIFF
--- a/kvido
+++ b/kvido
@@ -178,8 +178,11 @@ Commands:
   instructions <subcommand>         Per-agent instructions (read, write, list, tree)
   current <get|dump|summary|set|append|clear>  Read/write current focus sections (state/current.md)
   migrate                           Run lazy state migration (heartbeat-state/planner-state → state)
+  memory-sync [--status|--commit-only|--dry-run]  Commit & push KVIDO_HOME to git remote
   scripts/<script>.sh [args]        Direct script dispatch (backward compat)
   agents/<script>.sh [args]         Direct agent dispatch (backward compat)
+
+Note: personal scripts in \$KVIDO_HOME/scripts/ take precedence over plugin scripts.
 
 Flags:
   --root                            Print plugin root path
@@ -290,10 +293,15 @@ WRAPPER
     ;;
   *)
     # Try auto-resolve as short command name → scripts/*.sh
+    # Checks $KVIDO_HOME/scripts/ first (personal overrides), then $KVIDO_ROOT/scripts/ (plugin).
     if [[ $# -gt 0 ]]; then
       _RESOLVED=""
       _NAME="${1%.sh}"
-      if [[ -f "$KVIDO_ROOT/scripts/$_NAME.sh" ]]; then
+      # 1. Personal override: $KVIDO_HOME/scripts/<name>.sh
+      if [[ -f "$KVIDO_HOME/scripts/$_NAME.sh" ]]; then
+        _RESOLVED="$KVIDO_HOME/scripts/$_NAME.sh"
+      # 2. Plugin scripts: flat, nested, or deep-search
+      elif [[ -f "$KVIDO_ROOT/scripts/$_NAME.sh" ]]; then
         _RESOLVED="$KVIDO_ROOT/scripts/$_NAME.sh"
       elif [[ -f "$KVIDO_ROOT/scripts/$_NAME/$_NAME.sh" ]]; then
         _RESOLVED="$KVIDO_ROOT/scripts/$_NAME/$_NAME.sh"


### PR DESCRIPTION
## Summary

Personal infrastructure scripts (like memory-sync.sh) now live in `$KVIDO_HOME/scripts/` instead of shipping with the plugin.

## Changes

- **Relocation**: memory-sync.sh moved from plugin to KVIDO_HOME user directory
- **Override mechanism**: kvido CLI now searches `$KVIDO_HOME/scripts/` before plugin scripts, giving users a clean path to override or add personal scripts without modifying the plugin

## Why

This enables users to maintain personal utility scripts (memory-sync, custom fetchers, etc.) in their KVIDO_HOME directory without conflicts or plugin updates overwriting them.

## Testing

- Verify kvido CLI finds scripts in $KVIDO_HOME/scripts/ with higher priority
- Confirm memory-sync works from KVIDO_HOME location
- Check that plugin scripts still work as fallback when not overridden