### PR TITLE
docs(agents): add sandbox acli/gws Linux D-Bus workaround

### DIFF
--- a/agents/gatherer.md
+++ b/agents/gatherer.md
@@ -99,6 +99,18 @@ kvido state set gatherer.eod_done "$(date +%Y-%m-%d)"
 
 Urgency: `immediate` (meeting <15min, review request, blocking), `normal` (new MR, assigned issue), `low` (status changes, FYI).
 
+## Sandbox Constraints
+
+**Goal:** Avoid misdiagnosing sandbox-induced auth failures as credential problems.
+
+### acli and gws on Linux (D-Bus / gnome-keyring)
+
+On Linux, `acli` and `gws` store credentials in the gnome-keyring via a D-Bus Unix socket. When the Claude Code sandbox blocks Unix domain sockets (default behavior), both tools return `unauthorized` even when credentials are valid and the network domains are allowed.
+
+If you see `unauthorized` from `acli` or `gws`, check sandbox settings first — do not assume credentials are wrong. The fix requires `allowAllUnixSockets: true` in `~/.config/kvido/settings.json` and `allowRead` for `~/.config/acli` and `~/.config/gws`. Fall back to MCP tools (`mcp__claude_ai_Atlassian__*`) when the source file defines an MCP fallback.
+
+---
+
 ## Rules
 
 - **No Slack messages.** Return NL text to the caller only.

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -136,6 +136,40 @@ Source: {{SOURCE_REF}}
 - `Type:` — always `worker-report`
 - `Source:` — include only if `{{SOURCE_REF}}` is non-empty
 
+## Sandbox Constraints
+
+**Goal:** Avoid misdiagnosing sandbox-induced auth failures as credential problems.
+
+### acli and gws on Linux (D-Bus / gnome-keyring)
+
+On Linux, `acli` and `gws` store credentials in the gnome-keyring, which is accessed via a D-Bus Unix socket. When the Claude Code sandbox blocks Unix domain sockets (default behavior), both tools return `unauthorized` even when credentials are valid and the Atlassian/Google network domains are allowed.
+
+Symptoms:
+- `acli issue list` or any acli command exits with `unauthorized` or `401`
+- `gws` commands fail with authentication errors despite correct credentials
+
+Fix — ensure `~/.config/kvido/settings.json` contains:
+
+```json
+{
+  "sandbox": {
+    "allowAllUnixSockets": true,
+    "filesystem": {
+      "read": {
+        "allowOnly": [
+          "~/.config/acli",
+          "~/.config/gws"
+        ]
+      }
+    }
+  }
+}
+```
+
+If you see `unauthorized` from `acli` or `gws`, check sandbox settings first — do not assume credentials are wrong or try to re-authenticate.
+
+---
+
 ## Common Mistakes
 
 | Mistake | Fix |


### PR DESCRIPTION
## Summary

- Adds a **Sandbox Constraints** section to `agents/worker.md` explaining why `acli` and `gws` return `unauthorized` on Linux when the Claude Code sandbox blocks Unix domain sockets (gnome-keyring / D-Bus)
- Adds the same constraint (shorter form) to `agents/gatherer.md` with a reminder to fall back to MCP tools when available
- Documents the required fix: `allowAllUnixSockets: true` in settings.json + `allowRead` for `~/.config/acli` and `~/.config/gws`

Motivation: learning feedback `feedback/sandbox_acli` (2026-04-01) shows this issue recurs — agents repeatedly misdiagnose a sandbox config problem as a credential failure.

## Test plan

- [ ] Read `agents/worker.md` — confirm Sandbox Constraints section appears before Common Mistakes
- [ ] Read `agents/gatherer.md` — confirm Sandbox Constraints section appears before Rules
- [ ] Verify no existing content was modified or removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)