### PR TITLE
docs(worker): never commit gitignored spec files

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -148,3 +148,4 @@ Source: {{SOURCE_REF}}
 | Pushing directly to main | Always push to feature branch — never to the default branch directly |
 | Branching worktree from a feature branch | Always base on the default branch — run ancestry check before pushing |
 | Referencing MRs/PRs without URL | Always include full clickable URL — plain "#123" is not actionable |
+| Committing design spec files | `docs/superpowers/specs/` is gitignored — never run `git add` or commit after writing a spec. Only implement; never commit the spec itself. |


### PR DESCRIPTION
## Summary

- Design spec files (`docs/superpowers/specs/*.md`) are gitignored but a worker previously tried to `git add` + commit them after writing one
- The commit appeared to succeed but was effectively empty (spec was silently ignored), causing confusion
- Added an explicit entry to the Common Mistakes table in `agents/worker.md`: never run `git add` or commit after writing a spec file

## Test plan

- [ ] Review the new Common Mistakes row in `agents/worker.md`
- [ ] Verify wording is clear: write spec → implement → no commit of the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)