### PR TITLE
fix(setup): add inbox/ and knowhow/ to structure bootstrap

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -71,6 +71,8 @@ For each enabled source, verify required config keys exist via `kvido config`. S
 mkdir -p $KVIDO_HOME/memory/{journal,weekly,projects,people,decisions,archive/{journal,weekly,decisions}}
 mkdir -p $KVIDO_HOME/instructions
 mkdir -p $KVIDO_HOME/tasks/{triage,todo,in-progress,done,failed,cancelled}
+mkdir -p $KVIDO_HOME/inbox
+mkdir -p $KVIDO_HOME/knowhow
 ```
 
 Create missing files with minimal content:


### PR DESCRIPTION
## Summary

- `inbox/` and `knowhow/` directories were missing from the Step 2 bootstrap `mkdir -p` commands in `commands/setup.md`
- Added two explicit `mkdir -p` lines for both directories so fresh installs create the complete expected structure

Fixes #238

## Test plan

- [ ] Run `/kvido:setup` on a fresh `KVIDO_HOME` and verify `inbox/` and `knowhow/` are created
- [ ] Run on an existing install — idempotent, no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)