### PR TITLE
feat(librarian): auto-archive done tasks older than 7 days

### DIFF
--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -83,6 +83,30 @@ Assess the current state — what's fresh, what's stale, what's missing — and 
 
 ---
 
+### Task Archival
+
+**Goal:** Keep `tasks/done/` small by moving old completed tasks to `tasks/archive/`.
+
+**When:** Always run as part of the maintenance cycle — after Cleanup, before Index.
+
+**How:**
+
+Run the archival script:
+
+```bash
+bash "$KVIDO_ROOT/scripts/maintenance/archive-done-tasks.sh" 7
+```
+
+The script:
+1. Reads `updated_at` from each task's frontmatter in `tasks/done/`.
+2. Falls back to file modification time when the field is missing.
+3. Moves tasks older than 7 days to `tasks/archive/` via `kvido task move`.
+4. Prints a summary line: `ARCHIVE_DONE_TASKS: archived=N skipped=M days=7`.
+
+**Report the summary line in your output** so the caller knows what was archived.
+
+---
+
 ### Lint
 
 **Goal:** Health-check the wiki for structural issues.

--- a/scripts/maintenance/archive-done-tasks.sh
+++ b/scripts/maintenance/archive-done-tasks.sh
@@ -17,6 +17,11 @@ DONE_DIR="$TASKS_DIR/done"
 ARCHIVE_DIR="$TASKS_DIR/archive"
 DAYS="${1:-7}"
 
+if ! [[ "$DAYS" =~ ^[0-9]+$ ]]; then
+  echo "Error: DAYS must be a positive integer" >&2
+  exit 1
+fi
+
 # Resolve the task.sh helper (prefer KVIDO_ROOT / script-relative path)
 _resolve_task_sh() {
   # Try KVIDO_ROOT (set when running inside Claude Code plugin context)
@@ -69,7 +74,7 @@ for f in "$DONE_DIR"/*.md; do
 
   if [[ -z "$file_epoch" ]]; then
     echo "WARN: could not determine age of $(basename "$f"), skipping" >&2
-    (( skipped++ )) || true
+    (( ++skipped ))
     continue
   fi
 
@@ -82,10 +87,10 @@ for f in "$DONE_DIR"/*.md; do
 
     if "$TASK_SH" move "$identifier" archive >/dev/null 2>&1; then
       echo "archived: $(basename "$f")"
-      (( archived++ )) || true
+      (( ++archived ))
     else
       echo "WARN: failed to archive $(basename "$f")" >&2
-      (( skipped++ )) || true
+      (( ++skipped ))
     fi
   fi
 done

--- a/scripts/maintenance/archive-done-tasks.sh
+++ b/scripts/maintenance/archive-done-tasks.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# archive-done-tasks.sh — Move done tasks older than N days to tasks/archive/
+#
+# Usage: archive-done-tasks.sh [days]
+#   days  — age threshold in days (default: 7)
+#
+# Reads UPDATED_AT from task frontmatter. Falls back to file modification
+# time when the field is missing or unparseable.
+#
+# Called by the librarian agent as part of its Cleanup step.
+
+set -euo pipefail
+
+KVIDO_HOME="${KVIDO_HOME:-$HOME/.config/kvido}"
+TASKS_DIR="$KVIDO_HOME/tasks"
+DONE_DIR="$TASKS_DIR/done"
+ARCHIVE_DIR="$TASKS_DIR/archive"
+DAYS="${1:-7}"
+
+# Resolve the task.sh helper (prefer KVIDO_ROOT / script-relative path)
+_resolve_task_sh() {
+  # Try KVIDO_ROOT (set when running inside Claude Code plugin context)
+  if [[ -n "${KVIDO_ROOT:-}" && -f "$KVIDO_ROOT/scripts/worker/task.sh" ]]; then
+    echo "$KVIDO_ROOT/scripts/worker/task.sh"
+    return
+  fi
+  # Try relative to this script's location
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local candidate="$script_dir/../worker/task.sh"
+  if [[ -f "$candidate" ]]; then
+    echo "$(cd "$(dirname "$candidate")" && pwd)/$(basename "$candidate")"
+    return
+  fi
+  echo "task.sh not found" >&2
+  exit 1
+}
+
+TASK_SH="$(_resolve_task_sh)"
+
+[[ ! -d "$DONE_DIR" ]] && exit 0
+
+mkdir -p "$ARCHIVE_DIR"
+
+now_epoch=$(date +%s)
+cutoff_epoch=$(( now_epoch - DAYS * 86400 ))
+
+archived=0
+skipped=0
+
+for f in "$DONE_DIR"/*.md; do
+  [[ -e "$f" ]] || continue  # glob with no matches
+
+  # Read UPDATED_AT from frontmatter
+  updated_at=$(grep -m1 '^updated_at:' "$f" 2>/dev/null | sed 's/updated_at:[[:space:]]*//' | tr -d '"' | tr -d "'" || true)
+
+  file_epoch=""
+  if [[ -n "$updated_at" ]]; then
+    # Parse ISO 8601 date — try date -d (GNU) then date -j (BSD/macOS)
+    file_epoch=$(date -d "$updated_at" +%s 2>/dev/null \
+      || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null \
+      || true)
+  fi
+
+  # Fallback to file modification time
+  if [[ -z "$file_epoch" ]]; then
+    file_epoch=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || true)
+  fi
+
+  if [[ -z "$file_epoch" ]]; then
+    echo "WARN: could not determine age of $(basename "$f"), skipping" >&2
+    (( skipped++ )) || true
+    continue
+  fi
+
+  if (( file_epoch < cutoff_epoch )); then
+    # Extract slug from filename (strip leading NNN- task ID prefix)
+    slug=$(basename "$f" .md | sed 's/^[0-9]*-//')
+    task_id=$(basename "$f" .md | grep -o '^[0-9]*' || echo "")
+
+    identifier="${task_id:-$slug}"
+
+    if "$TASK_SH" move "$identifier" archive >/dev/null 2>&1; then
+      echo "archived: $(basename "$f")"
+      (( archived++ )) || true
+    else
+      echo "WARN: failed to archive $(basename "$f")" >&2
+      (( skipped++ )) || true
+    fi
+  fi
+done
+
+echo "ARCHIVE_DONE_TASKS: archived=$archived skipped=$skipped days=$DAYS"

--- a/scripts/worker/task.sh
+++ b/scripts/worker/task.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 
 KVIDO_HOME="${KVIDO_HOME:-$HOME/.config/kvido}"
 TASKS_DIR="${TASKS_DIR:-${KVIDO_HOME}/tasks}"
-STATUSES="triage todo in-progress done failed cancelled"
+STATUSES="triage todo in-progress done failed cancelled archive"
 
 # shellcheck source=../lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
@@ -569,7 +569,7 @@ Subcommands:
   read <id|slug>              Print frontmatter fields as KEY="value" (consistently quoted)
   read-raw <id|slug>          Print raw markdown file
   update <id|slug> <field> <value>  Update a frontmatter field
-  move <id|slug> <status>     Move task (triage|todo|in-progress|done|failed|cancelled)
+  move <id|slug> <status>     Move task (triage|todo|in-progress|done|failed|cancelled|archive)
   list <status> [--sort priority] [--source SRC] [--format human|raw|slug-title]  List tasks
   find <id|slug>              Print current status of task
   note <id|slug> "<text>"     Append text to ## Worker Notes


### PR DESCRIPTION
## Summary

- Adds `scripts/maintenance/archive-done-tasks.sh` — reads `updated_at` from task frontmatter, falls back to file mtime, moves tasks older than 7 days from `tasks/done/` to `tasks/archive/` via `kvido task move`
- Adds **Task Archival** section to `agents/librarian.md` — runs the script as part of the maintenance cycle (after Cleanup, before Index), reports the summary line in output

## Test plan

- [ ] Run `bash scripts/maintenance/archive-done-tasks.sh 7` against a `$KVIDO_HOME` with some old done tasks — verify they land in `tasks/archive/`
- [ ] Run with `0` days to force all done tasks to archive — verify output line `ARCHIVE_DONE_TASKS: archived=N skipped=0 days=0`
- [ ] Run against an empty `tasks/done/` — should exit cleanly with `archived=0`
- [ ] Trigger librarian agent maintenance and confirm `ARCHIVE_DONE_TASKS:` line appears in its output

🤖 Generated with [Claude Code](https://claude.com/claude-code)