### PR TITLE
feat(reviewer): auto-schedule re-review task after FAIL+fix cycle

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -146,7 +146,10 @@ RESULT=FAIL
 PR: https://github.com/org/repo/pull/42
 Task: {{TASK_SLUG}}
 Type: reviewer-error
+SCHEDULE_REVIEW: PR_NUMBER=42 PR_URL=https://github.com/org/repo/pull/42 after_task=<worker_fix_slug>
 ```
+
+**`SCHEDULE_REVIEW` line:** Include only when `RESULT=FAIL` and `PR_NUMBER` is non-empty. Set `after_task` to `{{TASK_SLUG}}` (heartbeat will use it to link the re-review to the fix worker task). This signals heartbeat to auto-create a new code review task once the fix is delivered, closing the FAIL→fix→re-review loop without planner intervention.
 
 ## Agent Memory
 
@@ -165,5 +168,5 @@ Don't duplicate facts from `$KVIDO_HOME/memory/` — agent memory is for review-
 
 - **Never push or merge.** Read-only access to the repository. Never run `git push`, `git merge`, or `gh pr merge`.
 - **No Slack messages.** Return NL output — heartbeat handles delivery.
-- **One task per PR.** Do not create additional tasks. If a fix is needed, return FAIL and let planner handle follow-up.
+- **One task per PR.** Do not create additional tasks directly. If a fix is needed, return FAIL and emit `SCHEDULE_REVIEW` — heartbeat creates the re-review task, not the reviewer.
 - **User approves merges.** Even on PASS, never trigger merge. Only the user merges PRs.

--- a/skills/heartbeat-deliver/SKILL.md
+++ b/skills/heartbeat-deliver/SKILL.md
@@ -73,6 +73,25 @@ Chat uses ack reactions only (see above), not status edits.
 | researcher | `event` | per researcher's suggested urgency in each finding block | Split output by `RESEARCHER FINDING:` markers — deliver each finding as a separate notification |
 | ingest | `event` | `normal` | Parse `INGESTED:` line from output. Use `--var message="<INGESTED line>"`. |
 
+#### Reviewer SCHEDULE_REVIEW handling
+
+When a reviewer agent completes with `RESULT=FAIL`, scan the output for a `SCHEDULE_REVIEW:` line:
+
+```
+SCHEDULE_REVIEW: PR_NUMBER=<N> PR_URL=<url> after_task=<slug>
+```
+
+If found:
+
+1. Parse `PR_NUMBER`, `PR_URL`, and `after_task` from the line.
+2. Create a new code review task: `kvido task create --title "Code review: PR #<PR_NUMBER>" --instruction "Review PR #<PR_NUMBER> at <PR_URL> after fix by <after_task>. PR_NUMBER=<N> PR_URL=<url>" --source reviewer --priority medium --size s`
+3. Move the task directly to `todo` (skip triage): `kvido task move <new-slug> todo`
+4. Log: `kvido log add heartbeat schedule-review --message "PR #<N>: re-review task <new-slug> created, waiting for fix <after_task>"`
+
+**Timing:** The new review task is created immediately when the FAIL result is delivered — the planner will schedule it naturally when the referenced fix worker task completes (it will see the todo task and the merged/closed PR). No blocking dependency is set in the task system; the planner observes PR state and task state as usual.
+
+**Only on FAIL:** If reviewer output has `RESULT=PASS`, ignore any `SCHEDULE_REVIEW` line (should not be present, but guard defensively).
+
 #### Chat query-save handling
 
 When chat agent output contains `Save-offer: true`, after delivering the normal chat reply:


### PR DESCRIPTION
## Summary

- When reviewer returns `RESULT=FAIL` and `PR_NUMBER` is non-empty, it now emits a `SCHEDULE_REVIEW:` line in its output
- `heartbeat-deliver` parses this line and auto-creates a new code review task (skipping triage, going directly to `todo` per `reviews_skip_triage` rule)
- Closes the FAIL→fix→re-review loop without requiring planner intervention — eliminates latency from 7+ observed multi-round review cycles (tasks #80/#82, #92/#95, #96/#99, #102/#114/#126, #154)

## Test plan

- [ ] Trigger a reviewer run that returns FAIL on a PR — verify `SCHEDULE_REVIEW:` line appears in output
- [ ] Verify heartbeat-deliver creates re-review task and moves it directly to `todo`
- [ ] Verify PASS result does NOT emit or process `SCHEDULE_REVIEW`
- [ ] Verify log entry is written: `kvido log add heartbeat schedule-review ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)