### PR TITLE
fix(gitlab-mrs): include web_url in MR output

### DIFF
--- a/scripts/fetch/gitlab-mrs.sh
+++ b/scripts/fetch/gitlab-mrs.sh
@@ -73,12 +73,12 @@ process_repo() {
 
   if [[ "$authored_count" -gt 0 ]]; then
     echo "My MRs:"
-    echo "$authored" | jq -r '.[] | "  !\(.iid): \(if .draft then "DRAFT " else "" end)\(.title) [CI: \((.head_pipeline // {}).status // "no pipeline"), \(if .approved then "approved" elif (.reviewers // []) | length > 0 then "\(.reviewers | length) reviewer(s)" else "no reviewers" end)]"' 2>/dev/null || echo "ERROR: failed to format authored MRs for $name (exit $?)" >&2
+    echo "$authored" | jq -r '.[] | "  !\(.iid): \(if .draft then "DRAFT " else "" end)\(.title) [CI: \((.head_pipeline // {}).status // "no pipeline"), \(if .approved then "approved" elif (.reviewers // []) | length > 0 then "\(.reviewers | length) reviewer(s)" else "no reviewers" end)] URL: \(.web_url)"' 2>/dev/null || echo "ERROR: failed to format authored MRs for $name (exit $?)" >&2
   fi
 
   if [[ "$reviewing_count" -gt 0 ]]; then
     echo "Reviewing:"
-    echo "$reviewing" | jq -r '.[] | "  !\(.iid): \(.title) (by \((.author // {}).username // "?")) [CI: \((.head_pipeline // {}).status // "no pipeline")]"' 2>/dev/null || echo "ERROR: failed to format reviewing MRs for $name (exit $?)" >&2
+    echo "$reviewing" | jq -r '.[] | "  !\(.iid): \(.title) (by \((.author // {}).username // "?")) [CI: \((.head_pipeline // {}).status // "no pipeline")] URL: \(.web_url)"' 2>/dev/null || echo "ERROR: failed to format reviewing MRs for $name (exit $?)" >&2
   fi
 
   echo ""


### PR DESCRIPTION
## Summary

- `gitlab-mrs.sh` output only `\!IID: title [CI: ...]` per MR — no URL
- Gatherer LLM agent was forced to construct URLs from the config key name (e.g. `mm-iam-stormm`), producing paths like `git.digital.cz/mm-iam-stormm/-/merge_requests/2` instead of the correct `git.digital.cz/mm/gitops/iam-stormm/-/merge_requests/2`
- Root cause: the config key does not reflect the GitLab project namespace when the local path structure differs (e.g. `mm/iam-stormm` on disk vs `mm/gitops/iam-stormm` on GitLab)

## Fix

Add `web_url` field to both authored and reviewing MR lines in the `jq` output. The URL is provided by `glab` which resolves it via the git remote — always correct regardless of how the repo is organised locally.

Before:
```
=== mm-iam-stormm ===
My MRs:
  \!2: fix auth flow [CI: passed, 1 reviewer(s)]
```

After:
```
=== mm-iam-stormm ===
My MRs:
  \!2: fix auth flow [CI: passed, 1 reviewer(s)] URL: https://git.digital.cz/mm/gitops/iam-stormm/-/merge_requests/2
```

## Test plan

- [ ] Run `kvido gitlab-mrs` against a repo where the config key path differs from the GitLab namespace (e.g. `mm-iam-stormm`), verify URL points to `mm/gitops/iam-stormm`
- [ ] Run `kvido gitlab-mrs` against a standard repo, verify URL is correct
- [ ] Verify gatherer heartbeat report includes correct clickable MR URLs

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)