### PR TITLE
chore: bump plugin version to 0.39.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kvido",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Personal AI workflow assistant — heartbeat, planner, worker, sources",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bumps `plugin.json` version from `0.39.0` to `0.39.1` to match the latest GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)