### PR TITLE
feat(heartbeat): auto-sleep detection (option A)

### DIFF
--- a/scripts/heartbeat/heartbeat.sh
+++ b/scripts/heartbeat/heartbeat.sh
@@ -65,6 +65,22 @@ if [[ -n "$SLEEP_UNTIL" && "$SLEEP_UNTIL" != "null" ]]; then
   fi
 fi
 
+# Auto-sleep detection — trigger sleep mode after hours when idle long enough
+AUTO_SLEEP_TRIGGERED="false"
+if [[ "$SLEEP_ACTIVE" == "false" ]]; then
+  AUTO_SLEEP_AFTER_HOUR=$(kvido config get heartbeat.auto_sleep.after_hour 2>/dev/null || echo "21")
+  AUTO_SLEEP_IDLE_MIN=$(kvido config get heartbeat.auto_sleep.idle_minutes 2>/dev/null || echo "60")
+  # Normalize: strip non-numeric (fallback to defaults if empty/null)
+  [[ -z "$AUTO_SLEEP_AFTER_HOUR" || "$AUTO_SLEEP_AFTER_HOUR" == "null" ]] && AUTO_SLEEP_AFTER_HOUR=21
+  [[ -z "$AUTO_SLEEP_IDLE_MIN" || "$AUTO_SLEEP_IDLE_MIN" == "null" ]] && AUTO_SLEEP_IDLE_MIN=60
+  if (( HOUR >= AUTO_SLEEP_AFTER_HOUR && INTERACTION_AGO_MIN >= AUTO_SLEEP_IDLE_MIN )); then
+    SLEEP_UNTIL=$(date -d 'tomorrow 06:00' -Iseconds)
+    kvido state set heartbeat.sleep_until "$SLEEP_UNTIL"
+    SLEEP_ACTIVE="true"
+    AUTO_SLEEP_TRIGGERED="true"
+  fi
+fi
+
 # Load adaptive rules from central settings.json via config.sh
 CONFIG="$PLUGIN_ROOT/scripts/config.sh"
 
@@ -204,6 +220,9 @@ echo "TURBO_ACTIVE=$TURBO_ACTIVE"
 echo "TURBO_UNTIL=$TURBO_UNTIL"
 echo "SLEEP_ACTIVE=$SLEEP_ACTIVE"
 echo "SLEEP_UNTIL=$SLEEP_UNTIL"
+echo "AUTO_SLEEP_TRIGGERED=$AUTO_SLEEP_TRIGGERED"
+echo "AUTO_SLEEP_AFTER_HOUR=${AUTO_SLEEP_AFTER_HOUR:-21}"
+echo "AUTO_SLEEP_IDLE_MIN=${AUTO_SLEEP_IDLE_MIN:-60}"
 echo "TARGET_PRESET=$TARGET_PRESET"
 echo "ACTIVE_PRESET=$ACTIVE_PRESET"
 echo "CRON_JOB_ID=$CRON_JOB_ID"


### PR DESCRIPTION
## Summary

- After configurable hour (default 21:00), if no interaction for >= N minutes (default 60), heartbeat automatically triggers sleep mode until tomorrow 06:00
- Reads config from `heartbeat.auto_sleep.after_hour` and `heartbeat.auto_sleep.idle_minutes` (with sane defaults)
- Sets `SLEEP_ACTIVE=true`, persists `heartbeat.sleep_until` to state, outputs `AUTO_SLEEP_TRIGGERED=true`
- New KV output variables: `AUTO_SLEEP_TRIGGERED`, `AUTO_SLEEP_AFTER_HOUR`, `AUTO_SLEEP_IDLE_MIN`

## Test plan

- [ ] Verify heartbeat outputs `AUTO_SLEEP_TRIGGERED=false` when SLEEP_ACTIVE was already true before the block
- [ ] Verify `AUTO_SLEEP_TRIGGERED=true` when hour >= after_hour and INTERACTION_AGO_MIN >= idle_minutes
- [ ] Verify sleep mode zone logic (`ZONE=sleep`, `TARGET_PRESET=sleep`) is set correctly after auto-sleep triggers
- [ ] Verify `SLEEP_UNTIL` is set to tomorrow 06:00 in state and echoed in output
- [ ] Verify custom config values override defaults

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)