### PR TITLE
fix(heartbeat): correct kvido config call syntax in auto-sleep detection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kvido",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Personal AI workflow assistant — heartbeat, planner, worker, sources",
   "license": "MIT",
   "keywords": [

--- a/scripts/heartbeat/heartbeat.sh
+++ b/scripts/heartbeat/heartbeat.sh
@@ -68,8 +68,8 @@ fi
 # Auto-sleep detection — trigger sleep mode after hours when idle long enough
 AUTO_SLEEP_TRIGGERED="false"
 if [[ "$SLEEP_ACTIVE" == "false" ]]; then
-  AUTO_SLEEP_AFTER_HOUR=$(kvido config get heartbeat.auto_sleep.after_hour 2>/dev/null || echo "21")
-  AUTO_SLEEP_IDLE_MIN=$(kvido config get heartbeat.auto_sleep.idle_minutes 2>/dev/null || echo "60")
+  AUTO_SLEEP_AFTER_HOUR=$(kvido config 'heartbeat.auto_sleep.after_hour' 2>/dev/null || echo "21")
+  AUTO_SLEEP_IDLE_MIN=$(kvido config 'heartbeat.auto_sleep.idle_minutes' 2>/dev/null || echo "60")
   # Normalize: strip non-numeric (fallback to defaults if empty/null)
   [[ -z "$AUTO_SLEEP_AFTER_HOUR" || "$AUTO_SLEEP_AFTER_HOUR" == "null" ]] && AUTO_SLEEP_AFTER_HOUR=21
   [[ -z "$AUTO_SLEEP_IDLE_MIN" || "$AUTO_SLEEP_IDLE_MIN" == "null" ]] && AUTO_SLEEP_IDLE_MIN=60


### PR DESCRIPTION
## Summary

- `kvido config get <key>` was treating `get` as the key and the actual key name as the default value
- When key `get` didn't exist in settings.json, the config returned the literal string `heartbeat.auto_sleep.after_hour` as the default
- This caused an arithmetic error: `((: heartbeat.auto_sleep.after_hour: syntax error: invalid arithmetic operator`
- Fixed by using correct syntax: `kvido config '<key>'`
- Bumped version to 0.40.1

## Test plan

- [ ] Verify heartbeat runs without arithmetic syntax error in auto-sleep section
- [ ] Verify auto-sleep triggers correctly after configured hour when idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)