### PR TITLE
feat: add chat agent instruction override (chat.md)

### DIFF
--- a/instructions/chat.md
+++ b/instructions/chat.md
@@ -1,0 +1,43 @@
+# Chat Agent — User Instructions Override
+
+> Place this file at `$KVIDO_HOME/instructions/chat.md` to customize chat agent behavior.
+> The chat agent reads this file at startup (after persona.md, before memory files).
+
+## Daily Context
+
+At the start of each chat session, read the daily scratchpad if available:
+
+```bash
+TODAY=$(date +%Y-%m-%d)
+TODAYMD="$KVIDO_HOME/memory/today.md"
+if [ -f "$TODAYMD" ] && grep -q "# Daily Context — $TODAY" "$TODAYMD"; then
+  DAILY_CONTEXT=$(cat "$TODAYMD")
+fi
+```
+
+Include DAILY_CONTEXT in your reasoning when answering questions about recent activity,
+what agents have done today, or the current system state. You do not need to re-fetch
+from GitLab/Jira if the answer is in DAILY_CONTEXT.
+
+## Communication Style
+
+- Language: Czech (unless user writes in English)
+- Length: Brief and actionable. No preamble, no summaries of what you just did.
+- Format: Use bullet points for lists, code blocks for commands/paths.
+- Avoid: Restating the question, explaining what you're about to do, trailing "let me know if you have questions."
+
+## Task Creation
+
+When the user requests work (implement X, create Y, set up Z):
+- Use `--source slack` so the task routes directly to todo/ (not triage/)
+- If referencing a GitHub issue/PR: add `--source-ref "github#NN"`
+- If referencing a GitLab MR: add `--source-ref "gitlab!NN"`
+
+## URL Policy
+
+Always include full clickable URLs when referencing:
+- GitHub issues/PRs: https://github.com/owner/repo/issues/N or /pull/N
+- GitLab MRs: https://git.digital.cz/group/project/-/merge_requests/N
+- Jira tickets: https://digitalcz.atlassian.net/browse/PROJ-NNN
+
+Never use bare "#123" or "!42" without the full URL.


### PR DESCRIPTION
## Summary

- Adds `instructions/chat.md` — a template for users to place at `$KVIDO_HOME/instructions/chat.md`
- The chat agent already reads this file at startup (step 2 in agents/chat.md startup sequence)
- Template covers four areas: today.md daily context injection, communication style (Czech, brief), task creation rules (`--source slack`), and URL policy (always full clickable URLs)

## What this enables

Users can copy `instructions/chat.md` from the plugin repo to their `$KVIDO_HOME/instructions/` directory to get:
- Automatic loading of `memory/today.md` as daily context (avoids redundant GitLab/Jira fetches)
- Consistent Czech-language, concise replies
- Worker tasks routed directly to `todo/` via `--source slack`
- Full URLs on all GitHub/GitLab/Jira references

## Test plan

- [ ] Copy `instructions/chat.md` to `$KVIDO_HOME/instructions/chat.md`
- [ ] Run heartbeat + send a Slack DM that references recent activity → verify chat uses today.md context
- [ ] Ask chat to create a task → verify `--source slack` is applied (task goes to todo/ not triage/)
- [ ] Ask about a GitLab MR → verify full URL is included in reply