### PR TITLE
chore: bump version to 0.42.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kvido",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Personal AI workflow assistant — heartbeat, planner, worker, sources",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Release v0.42.0

Bump plugin version from 0.41.0 to 0.42.0.

### Changelog since v0.41.0

- fix(heartbeat): use wh_start config for auto-sleep wake time (PR #246)
- feat(today.md): formal split — user activity context vs system log (PR #248)